### PR TITLE
feat: support the parameterized IAM Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ result, _ := client.GenerateText(
 println(result.Text)
 ```
 
+### Customization
+If you want to use Watsonx test environment, choose one of the following methods:
+
+#### Option 1: Using Environment Variables
+
+Specify the Watsonx URL and IAM endpoint using environment variables:
+```sh
+export WATSONX_URL_HOST="us-south.ml.test.cloud.ibm.com"
+export WATSONX_IAM_HOST="iam.test.cloud.ibm.com"
+```
+
+#### Option 2: Using the `NewClient` Function Parameters
+
+Specify the Watsonx URL and IAM endpoint through the parameters of the NewClient function:
+```go
+client, err := wx.NewClient(
+  wx.WithURL("us-south.ml.test.cloud.ibm.com"),
+  wx.WithIAM("iam.test.cloud.ibm.com"),
+  wx.WithWatsonxAPIKey(apiKey),
+  wx.WithWatsonxProjectID(projectID),
+)
+```
+
 ## Development Setup
 
 ### Tests

--- a/pkg/models/client_option.go
+++ b/pkg/models/client_option.go
@@ -4,6 +4,7 @@ type ClientOption func(*ClientOptions)
 
 type ClientOptions struct {
 	URL        string
+	IAM        string
 	Region     IBMCloudRegion
 	APIVersion string
 
@@ -14,6 +15,12 @@ type ClientOptions struct {
 func WithURL(url string) ClientOption {
 	return func(o *ClientOptions) {
 		o.URL = url
+	}
+}
+
+func WithIAM(iam string) ClientOption {
+	return func(o *ClientOptions) {
+		o.IAM = iam
 	}
 }
 

--- a/pkg/models/iam.go
+++ b/pkg/models/iam.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	IAMEndpoint = "https://iam.cloud.ibm.com/identity/token"
+	TokenPath string = "/identity/token"
 )
 
 type IAMToken struct {
@@ -23,7 +23,7 @@ type TokenResponse struct {
 	Expiration  int64  `json:"expiration"`
 }
 
-func GenerateToken(client Doer, watsonxApiKey WatsonxAPIKey) (IAMToken, error) {
+func GenerateToken(client Doer, watsonxApiKey WatsonxAPIKey, iamCloudHost string) (IAMToken, error) {
 	values := url.Values{
 		"grant_type": {"urn:ibm:params:oauth:grant-type:apikey"},
 		"apikey":     {watsonxApiKey},
@@ -31,7 +31,12 @@ func GenerateToken(client Doer, watsonxApiKey WatsonxAPIKey) (IAMToken, error) {
 
 	payload := strings.NewReader(values.Encode())
 
-	req, err := http.NewRequest(http.MethodPost, IAMEndpoint, payload)
+	iamTokenEndpoint := url.URL{
+		Scheme:   "https",
+		Host:     iamCloudHost,
+		Path:     TokenPath,
+	}
+	req, err := http.NewRequest(http.MethodPost, iamTokenEndpoint.String(), payload)
 	if err != nil {
 		return IAMToken{}, err
 	}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -12,6 +12,9 @@ type (
 )
 
 const (
+	WatsonxURLEnvVarName = "WATSONX_URL_HOST"
+	WatsonxIAMEnvVarName = "WATSONX_IAM_HOST"
+
 	WatsonxAPIKeyEnvVarName    = "WATSONX_API_KEY"
 	WatsonxProjectIDEnvVarName = "WATSONX_PROJECT_ID"
 

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -12,8 +12,8 @@ type (
 )
 
 const (
-	WatsonxURLEnvVarName = "WATSONX_URL_HOST"
-	WatsonxIAMEnvVarName = "WATSONX_IAM_HOST"
+	WatsonxURLEnvVarName = "WATSONX_URL_HOST" // Override the default URL host '*.ml.cloud.ibm.com'
+	WatsonxIAMEnvVarName = "WATSONX_IAM_HOST" // Override the default IAM host 'iam.cloud.ibm.com'
 
 	WatsonxAPIKeyEnvVarName    = "WATSONX_API_KEY"
 	WatsonxProjectIDEnvVarName = "WATSONX_PROJECT_ID"


### PR DESCRIPTION
I need to use `us-south.ml.test.cloud.ibm.com` and `iam.test.cloud.ibm.com` for dev/test or demo environments. As you know, the IAM endpoint is hard code, so it's necessary to parameterize IAM endpoint.