### PR TITLE
Feat: Enable Chat Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ result, _ := client.GenerateText(
 println(result.Text)
 ```
 
+Stream Generation:
+
+```go
+dataChan, _ := client.GenerateTextStream(
+    "meta-llama/llama-3-70b-instruct",
+    "Hi, who are you?",
+    wx.WithTemperature(0.9),
+    wx.WithTopP(.5),
+    wx.WithTopK(10),
+    wx.WithMaxNewTokens(512),
+)
+
+generatedText := ""
+
+for data := range dataChan {
+    generatedText += data.Text
+}
+
+println(generatedText)
+```
+
+Note: The `GenerateTextStream` function is ideal for long text generation tasks, especially when using Server-Sent Events (SSE) for real-time text streaming.
+
 ### Customization
 If you want to use Watsonx test environment, choose one of the following methods:
 

--- a/pkg/internal/tests/models/generate_test.go
+++ b/pkg/internal/tests/models/generate_test.go
@@ -161,7 +161,7 @@ func TestGenerateTextWithNoPrompt(t *testing.T) {
 		t.Fatalf("Expected an error, but got nil")
 	}
 
-	if err != nil && err.Error() != "prompt cannot be empty" {
+	if err.Error() != "prompt cannot be empty" {
 		t.Fatalf("Expected error to be 'prompt cannot be empty', but got %v", err)
 	}
 

--- a/pkg/internal/tests/models/generate_test.go
+++ b/pkg/internal/tests/models/generate_test.go
@@ -112,6 +112,69 @@ func TestGenerateText(t *testing.T) {
 	}
 }
 
+func TestGenerateTextStream(t *testing.T) {
+	client := getClient(t)
+
+	dataChan, err := client.GenerateTextStream(
+		"google/flan-ul2",
+		"Hi, who are you?",
+		wx.WithTemperature(0.9),
+		wx.WithTopP(.5),
+		wx.WithTopK(10),
+		wx.WithMinNewTokens(10),
+		wx.WithMaxNewTokens(10),
+		wx.WithRandomSeed(1),
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error, but got an error: %v", err)
+	}
+
+	expectedText := "I am a person. You are a"
+	generatedText := ""
+
+	for data := range dataChan {
+		generatedText += data.Text
+	}
+
+	if generatedText != expectedText {
+		t.Fatalf("Expected generated text to be %s, but got %s", expectedText, generatedText)
+	}
+
+}
+
+func TestGenerateTextWithNoPrompt(t *testing.T) {
+	client := getClient(t)
+
+	dataChan, err := client.GenerateTextStream(
+		"google/flan-ul2",
+		"",
+		wx.WithTemperature(0.9),
+		wx.WithTopP(.5),
+		wx.WithTopK(10),
+		wx.WithMinNewTokens(10),
+		wx.WithMaxNewTokens(10),
+		wx.WithRandomSeed(1),
+	)
+
+	if err == nil {
+		t.Fatalf("Expected an error, but got nil")
+	}
+
+	if err != nil && err.Error() != "prompt cannot be empty" {
+		t.Fatalf("Expected error to be 'prompt cannot be empty', but got %v", err)
+	}
+
+	generatedText := ""
+	for data := range dataChan {
+		generatedText += data.Text
+	}
+
+	if generatedText != "" {
+		t.Fatalf("Expected generated text to be empty, but got %s", generatedText)
+	}
+}
+
 func TestGenerateTextWithNilOptions(t *testing.T) {
 	client := getClient(t)
 

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -218,7 +219,7 @@ func (m *Client) generateTextStreamRequest(payload GenerateTextPayload) (<-chan 
 		for scanner.Scan() {
 			line := scanner.Text()
 
-			if !(len(line) > 6 && line[:6] == "data: ") {
+			if !strings.HasPrefix(line, "data: ") {
 				continue
 			}
 

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -1,31 +1,34 @@
 package models
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 )
 
 const (
-	GenerationEndpoint   string = "/ml/v1-beta/generation"
-	GenerateTextEndpoint string = GenerationEndpoint + "/text"
+	GenerationEndpoint         string = "/ml/v1/text"
+	GenerateTextEndpoint       string = GenerationEndpoint + "/generation"
+	GenerateTextStreamEndpoint string = GenerationEndpoint + "/generation_stream"
 )
 
 type StopReason = string
 
 const (
-	NotFinished        StopReason = "NOT_FINISHED"  // Possibly more tokens to be streamed
-	MaxTokens          StopReason = "MAX_TOKENS"    // Maximum requested tokens reached
-	EndOfSequenceToken StopReason = "EOS_TOKEN"     // End of sequence token encountered
-	Cancelled          StopReason = "CANCELLED"     // Request canceled by the client
-	TimeLimit          StopReason = "TIME_LIMIT"    // Time limit reached
-	StopSequence       StopReason = "STOP_SEQUENCE" // Stop sequence encountered
-	TokenLimit         StopReason = "TOKEN_LIMIT"   // Token limit reached
-	Error              StopReason = "ERROR"         // Error encountered
+	NotFinished        StopReason = "not_finished"  // Possibly more tokens to be streamed
+	MaxTokens          StopReason = "max_tokens"    // Maximum requested tokens reached
+	EndOfSequenceToken StopReason = "eos_token"     // End of sequence token encountered
+	Cancelled          StopReason = "cancelled"     // Request canceled by the client
+	TimeLimit          StopReason = "time_limit"    // Time limit reached
+	StopSequence       StopReason = "stop_sequence" // Stop sequence encountered
+	TokenLimit         StopReason = "token_limit"   // Token limit reached
+	Error              StopReason = "error"         // Error encountered
 )
 
 type GenerateTextResult struct {
@@ -134,4 +137,118 @@ func (m *Client) generateTextRequest(payload GenerateTextPayload) (generateTextR
 	}
 
 	return generateRes, nil
+}
+
+// GenerateTextStream generates completion text channel (stream) based on a given prompt and parameters
+func (m *Client) GenerateTextStream(model, prompt string, options ...GenerateOption) (<-chan GenerateTextResult, error) {
+	dataChan := make(chan GenerateTextResult)
+
+	if prompt == "" {
+		close(dataChan)
+		return dataChan, errors.New("prompt cannot be empty")
+	}
+
+	go func() {
+		defer close(dataChan)
+
+		m.CheckAndRefreshToken()
+
+		opts := &GenerateOptions{}
+		for _, opt := range options {
+			if opt != nil {
+				opt(opts)
+			}
+		}
+
+		payload := GenerateTextPayload{
+			ProjectID:  m.projectID,
+			Model:      model,
+			Prompt:     prompt,
+			Parameters: opts,
+		}
+
+		responseChan, _ := m.generateTextStreamRequest(payload)
+
+		for data := range responseChan {
+			for _, result := range data.Results {
+				dataChan <- result
+			}
+		}
+	}()
+
+	return dataChan, nil
+}
+
+// generateTextStreamRequest sends the generate request and handles the response using the http package.
+// Returns error on non-200 response
+func (m *Client) generateTextStreamRequest(payload GenerateTextPayload) (<-chan generateTextResponse, error) {
+	dataChan := make(chan generateTextResponse)
+
+	go func() {
+		defer close(dataChan)
+
+		params := url.Values{
+			"version": {m.apiVersion},
+		}
+
+		generateTextStreamUrl := url.URL{
+			Scheme:   "https",
+			Host:     m.url,
+			Path:     GenerateTextStreamEndpoint,
+			RawQuery: params.Encode(),
+		}
+
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			log.Println("error marshalling payload: ", err)
+			return
+		}
+
+		req, err := http.NewRequest(http.MethodPost, generateTextStreamUrl.String(), bytes.NewBuffer(payloadJSON))
+		if err != nil {
+			log.Println("error creating request: ", err)
+			return
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+m.token.value)
+		req.Header.Set("Accept", "text/event-stream")
+
+		res, err := m.httpClient.Do(req)
+		if err != nil {
+			log.Println("error making request: ", err)
+			return
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				log.Printf("request failed with status code %d", res.StatusCode)
+			} else {
+				log.Printf("request failed with status code %d and error %s", res.StatusCode, body)
+			}
+			return
+		}
+
+		scanner := bufio.NewScanner(res.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+
+			if !(len(line) > 6 && line[:6] == "data: ") {
+				continue
+			}
+
+			data := line[6:]
+			var generation generateTextResponse
+
+			if err := json.Unmarshal([]byte(data), &generation); err != nil {
+				log.Println("error unmarshalling data: ", err)
+				return
+			}
+			dataChan <- generation
+		}
+	}()
+
+	return dataChan, nil
 }

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -171,7 +171,8 @@ func (m *Client) GenerateTextStream(model, prompt string, options ...GenerateOpt
 }
 
 // generateTextStreamRequest sends the generate request and handles the response using the http package.
-// Returns error on non-200 response
+// Closes the channel on non-200 response
+// If any error happens during the streaming, it will be logged and the channel will be closed
 func (m *Client) generateTextStreamRequest(payload GenerateTextPayload) (<-chan generateTextResponse, error) {
 	dataChan := make(chan generateTextResponse)
 


### PR DESCRIPTION
#  Watsonx.ai chat streaming
Issue #12 

## Go Channels
1. Create a go data channel.
2. Make the request to the streaming endpoint that will return a `text/event-stream`.
3. Read each package using the scanner.
4. Marshal each chunk/package of the response.
5. Send the chunk to the channel.
6. Once the streaming is done, close the channel.

(When reading with the scanner the streaming response we must make sure that the line we are reading is the one that contains the data, so we must check if the prefix is `data: `)


## Error Handling:

Early Error Detection: If the prompt is empty, an error is returned right away, and the data channel is closed to avoid further processing.

Logging Errors: Errors during the HTTP request or data processing are logged, so any issues can be easily tracked and the channel closed.

## Future updates (Suggestion)
I believe is a good idea to use the `Result Pattern` so we could create a `StreamingResponse` that contains three attributes (Data, Err, success)
```go
type StreamingResponse struct {
	Data		GenerateTextResult	`json:"data"`
	Err			error				`json:"error"`
	Success 		bool					`json:"success"`
}
```
With this we can return a message without needing to distinguish from a data message or an error message. The option of an error channel is not too good as will introduce a massive complexity.
