### PR TITLE
Feat: add watsonx.ai embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ client, err := wx.NewClient(
 )
 ```
 
+#### Generate Text
+
 Generation:
 
 ```go
@@ -63,6 +65,36 @@ dataChan, _ := client.GenerateTextStream(
 
 for data := range dataChan {
   print(data.Text) // print the result as it's being generated
+}
+```
+
+#### Generate Embeddings
+
+Embedding | Single query:
+
+```go
+result, _ := client.EmbedQuery(
+	"ibm/slate-30m-english-rtrvr",
+	"Hello, world!",
+	wx.WithEmbeddingTruncateInputTokens(2), 
+	wx.WithEmbeddingReturnOptions(true),
+)
+
+embeddingVector := result.Results[0].Embedding
+```
+
+Embedding | Multiple docs:
+
+```go
+result, _ := clientl.EmbedDocuments(
+    "ibm/slate-30m-english-rtrvr",
+    []string{"Hello, world!", "Goodbye, world!"},
+    wx.WithEmbeddingTruncateInputTokens(2), 
+    wx.WithEmbeddingReturnOptions(true),
+)
+
+for _, doc := range result.Results {
+    fmt.Println(doc.Embedding)
 }
 ```
 

--- a/pkg/internal/tests/models/embedding_test.go
+++ b/pkg/internal/tests/models/embedding_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	wx "github.com/IBM/watsonx-go/pkg/models"
+	"reflect"
 	"testing"
 )
 
@@ -28,8 +30,55 @@ func TestEmbeddingSingleQuery(t *testing.T) {
 		t.Fatalf("Expected dimension of %d, but got %d", EmbeddingModelDimension, len(response.Results[0].Embedding))
 	}
 
+	if response.Results[0].Input != "" {
+		t.Fatalf("Expected input to be empty, but got %s", response.Results[0].Input)
+	}
+
 	if response.Model != EmbeddingModelId {
 		t.Fatalf("Expected model to be %s, but got %s", EmbeddingModelId, response.Model)
+	}
+}
+
+func TestEmbeddingSingleQueryWithOptions(t *testing.T) {
+	client := getClient(t)
+
+	text := "Hello, world!"
+
+	response, err := client.EmbedQuery(
+		EmbeddingModelId,
+		text,
+		wx.WithEmbeddingTruncateInputTokens(2),
+		wx.WithEmbeddingReturnOptions(true),
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error for embedding query, but got %v", err)
+	}
+
+	if len(response.Results) != 1 {
+		t.Fatalf("Expected 1 embedding in response, but got %d", len(response.Results))
+	}
+
+	if len(response.Results[0].Embedding) != EmbeddingModelDimension {
+		t.Fatalf("Expected dimension of %d, but got %d", EmbeddingModelDimension, len(response.Results[0].Embedding))
+	}
+
+	if response.Results[0].Input != text {
+		t.Fatalf("Expected input to be %s, but got %s", text, response.Results[0].Input)
+	}
+
+	if response.Model != EmbeddingModelId {
+		t.Fatalf("Expected model to be %s, but got %s", EmbeddingModelId, response.Model)
+	}
+
+	// the embedding must be different from the one without truncate options
+	responseNoOptions, err := client.EmbedQuery(EmbeddingModelId, text, wx.WithEmbeddingReturnOptions(true))
+	if err != nil {
+		t.Fatalf("Expected no error for embedding query, but got %v", err)
+	}
+
+	if reflect.DeepEqual(response.Results[0].Embedding, responseNoOptions.Results[0].Embedding) {
+		t.Fatalf("Expected different embeddings with and without options, but got the same")
 	}
 }
 
@@ -38,7 +87,7 @@ func TestEmbeddingMultipleQueries(t *testing.T) {
 
 	texts := []string{"Hello, world!", "How are you?"}
 
-	response, err := client.EmbedDocuments(EmbeddingModelId, texts)
+	response, err := client.EmbedDocuments(EmbeddingModelId, texts, wx.WithEmbeddingReturnOptions(true))
 
 	if err != nil {
 		t.Fatalf("Expected no error for embedding queries, but got %v", err)
@@ -55,6 +104,10 @@ func TestEmbeddingMultipleQueries(t *testing.T) {
 	for i, result := range response.Results {
 		if len(result.Embedding) != EmbeddingModelDimension {
 			t.Fatalf("Expected dimension of %d, but got %d for query %d", EmbeddingModelDimension, len(result.Embedding), i)
+		}
+
+		if result.Input != texts[i] {
+			t.Fatalf("Expected input to be %s, but got %s for query %d", texts[i], result.Input, i)
 		}
 	}
 

--- a/pkg/internal/tests/models/embedding_test.go
+++ b/pkg/internal/tests/models/embedding_test.go
@@ -1,0 +1,64 @@
+package test
+
+import (
+	"testing"
+)
+
+const (
+	EmbeddingModelId        = "ibm/slate-30m-english-rtrvr"
+	EmbeddingModelDimension = 384
+)
+
+func TestEmbeddingSingleQuery(t *testing.T) {
+	client := getClient(t)
+
+	text := "Hello, world!"
+
+	response, err := client.EmbedQuery(EmbeddingModelId, text)
+
+	if err != nil {
+		t.Fatalf("Expected no error for embedding query, but got %v", err)
+	}
+
+	if len(response.Results) != 1 {
+		t.Fatalf("Expected 1 embedding in response, but got %d", len(response.Results))
+	}
+
+	if len(response.Results[0].Embedding) != EmbeddingModelDimension {
+		t.Fatalf("Expected dimension of %d, but got %d", EmbeddingModelDimension, len(response.Results[0].Embedding))
+	}
+
+	if response.Model != EmbeddingModelId {
+		t.Fatalf("Expected model to be %s, but got %s", EmbeddingModelId, response.Model)
+	}
+}
+
+func TestEmbeddingMultipleQueries(t *testing.T) {
+	client := getClient(t)
+
+	texts := []string{"Hello, world!", "How are you?"}
+
+	response, err := client.EmbedDocuments(EmbeddingModelId, texts)
+
+	if err != nil {
+		t.Fatalf("Expected no error for embedding queries, but got %v", err)
+	}
+
+	if len(response.Results) != len(texts) {
+		t.Fatalf("Expected %d embeddings in response, but got %d", len(texts), len(response.Results))
+	}
+
+	if len(response.Results) != 2 {
+		t.Fatalf("Expected 2 embeddings in response, but got %d", len(response.Results))
+	}
+
+	for i, result := range response.Results {
+		if len(result.Embedding) != EmbeddingModelDimension {
+			t.Fatalf("Expected dimension of %d, but got %d for query %d", EmbeddingModelDimension, len(result.Embedding), i)
+		}
+	}
+
+	if response.Model != EmbeddingModelId {
+		t.Fatalf("Expected model to be %s, but got %s", EmbeddingModelId, response.Model)
+	}
+}

--- a/pkg/internal/tests/models/generate_test.go
+++ b/pkg/internal/tests/models/generate_test.go
@@ -35,27 +35,6 @@ func TestClientCreationWithPassing(t *testing.T) {
 	}
 }
 
-func getClient(t *testing.T) *wx.Client {
-	apiKey, projectID := os.Getenv(wx.WatsonxAPIKeyEnvVarName), os.Getenv(wx.WatsonxProjectIDEnvVarName)
-
-	if apiKey == "" {
-		t.Fatal("No watsonx API key provided")
-	}
-	if projectID == "" {
-		t.Fatal("No watsonx project ID provided")
-	}
-
-	client, err := wx.NewClient(
-		wx.WithWatsonxAPIKey(apiKey),
-		wx.WithWatsonxProjectID(projectID),
-	)
-	if err != nil {
-		t.Fatalf("Failed to create client for testing. Error: %v", err)
-	}
-
-	return client
-}
-
 func TestEmptyPromptError(t *testing.T) {
 	client := getClient(t)
 

--- a/pkg/internal/tests/models/test_utils.go
+++ b/pkg/internal/tests/models/test_utils.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	wx "github.com/IBM/watsonx-go/pkg/models"
+	"os"
+	"testing"
+)
+
+func getClient(t *testing.T) *wx.Client {
+	apiKey, projectID := os.Getenv(wx.WatsonxAPIKeyEnvVarName), os.Getenv(wx.WatsonxProjectIDEnvVarName)
+
+	if apiKey == "" {
+		t.Fatal("No watsonx API key provided")
+	}
+	if projectID == "" {
+		t.Fatal("No watsonx project ID provided")
+	}
+
+	client, err := wx.NewClient(
+		wx.WithWatsonxAPIKey(apiKey),
+		wx.WithWatsonxProjectID(projectID),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client for testing. Error: %v", err)
+	}
+
+	return client
+}

--- a/pkg/models/client.go
+++ b/pkg/models/client.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 )
 
@@ -88,6 +89,22 @@ func (m *Client) RefreshToken() error {
 	}
 	m.token = token
 	return nil
+}
+
+// generateUrlFromEndpoint generates a URL from the endpoint and the client's configuration
+func (m *Client) generateUrlFromEndpoint(endpoint string) string {
+	params := url.Values{
+		"version": {m.apiVersion},
+	}
+
+	generateTextURL := url.URL{
+		Scheme:   "https",
+		Host:     m.url,
+		Path:     endpoint,
+		RawQuery: params.Encode(),
+	}
+
+	return generateTextURL.String()
 }
 
 func buildBaseURL(region IBMCloudRegion) string {

--- a/pkg/models/embedding.go
+++ b/pkg/models/embedding.go
@@ -39,6 +39,7 @@ type embeddingResponse struct {
 	EmbeddingResponse
 }
 
+// EmbedDocuments embeds the given texts using the specified model.
 func (m *Client) EmbedDocuments(model string, texts []string, options ...EmbeddingOption) (EmbeddingResponse, error) {
 	m.CheckAndRefreshToken()
 
@@ -68,10 +69,13 @@ func (m *Client) EmbedDocuments(model string, texts []string, options ...Embeddi
 	return response.EmbeddingResponse, nil
 }
 
+// EmbedQuery embeds the given text using the specified model.
 func (m *Client) EmbedQuery(model string, text string, options ...EmbeddingOption) (EmbeddingResponse, error) {
 	return m.EmbedDocuments(model, []string{text}, options...)
 }
 
+// generateEmbeddingRequest sends a request to the embedding endpoint with the given payload.
+// return the response from the server if and only if the request is successful, code 200.
 func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingResponse, error) {
 	embeddingUrl := m.generateUrlFromEndpoint(EmbeddingEndpoint)
 

--- a/pkg/models/embedding.go
+++ b/pkg/models/embedding.go
@@ -1,0 +1,100 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	EmbeddingEndpoint string = "/ml/v1/text/embeddings"
+)
+
+type EmbeddingPayload struct {
+	ProjectID string   `json:"project_id"`
+	Model     string   `json:"model_id"`
+	Inputs    []string `json:"inputs"`
+}
+
+type EmbeddingResponse struct {
+	Model           string            `json:"model_id"`
+	Results         []EmbeddingResult `json:"results"`
+	CreatedAt       time.Time         `json:"created_at"`
+	InputTokenCount int               `json:"input_token_count"`
+}
+
+type EmbeddingResult struct {
+	Embedding []float64 `json:"embedding"`
+}
+
+type embeddingResponse struct {
+	Status     string `json:"status"`
+	StatusCode int    `json:"status_code"`
+	EmbeddingResponse
+}
+
+func (m *Client) EmbedDocuments(model string, texts []string) (EmbeddingResponse, error) {
+	m.CheckAndRefreshToken()
+
+	payload := EmbeddingPayload{
+		ProjectID: m.projectID,
+		Model:     model,
+		Inputs:    texts,
+	}
+
+	response, err := m.generateEmbeddingRequest(payload)
+	if err != nil {
+		return EmbeddingResponse{}, err
+	}
+
+	if len(response.Results) == 0 {
+		return EmbeddingResponse{}, errors.New("no result received")
+	}
+
+	return response.EmbeddingResponse, nil
+}
+
+func (m *Client) EmbedQuery(model string, text string) (EmbeddingResponse, error) {
+	return m.EmbedDocuments(model, []string{text})
+}
+
+func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingResponse, error) {
+	embeddingUrl := m.generateUrlFromEndpoint(EmbeddingEndpoint)
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return embeddingResponse{}, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, embeddingUrl, bytes.NewBuffer(payloadJSON))
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+m.token.value)
+
+	res, err := m.httpClient.Do(req)
+	if err != nil {
+		return embeddingResponse{}, err
+	}
+
+	statusCode := res.StatusCode
+	if statusCode != http.StatusOK {
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return embeddingResponse{}, fmt.Errorf("request failed with status code %d", statusCode)
+		}
+		return embeddingResponse{}, fmt.Errorf("request failed with status code %d and error %s", statusCode, body)
+	}
+	defer res.Body.Close()
+
+	var embeddingRes embeddingResponse
+
+	if err := json.NewDecoder(res.Body).Decode(&embeddingRes); err != nil {
+		return embeddingResponse{}, err
+	}
+
+	return embeddingRes, nil
+}

--- a/pkg/models/embedding_option.go
+++ b/pkg/models/embedding_option.go
@@ -1,0 +1,39 @@
+package models
+
+import "fmt"
+
+type EmbeddingOption func(*EmbeddingOptions)
+
+type EmbeddingOptions struct {
+	TruncateInputTokens *uint                   `json:"truncate_input_tokens,omitempty"`
+	ReturnOptions       *EmbeddingReturnOptions `json:"return_options,omitempty"`
+}
+
+type EmbeddingReturnOptions struct {
+	InputText bool `json:"input_text"`
+}
+
+func WithEmbeddingTruncateInputTokens(truncateInputTokens uint) EmbeddingOption {
+	if truncateInputTokens < 1 {
+		panic("TruncateInputTokens must be greater or equal to 1")
+	}
+
+	return func(opts *EmbeddingOptions) {
+		opts.TruncateInputTokens = &truncateInputTokens
+	}
+}
+
+func WithEmbeddingReturnOptions(inputText bool) EmbeddingOption {
+	return func(opts *EmbeddingOptions) {
+		opts.ReturnOptions = &EmbeddingReturnOptions{inputText}
+	}
+}
+
+func (ep *EmbeddingOptions) String() string {
+	return fmt.Sprintf(
+		"truncateInputTokens: %v\n"+
+			"returnOptions: %v\n",
+		ep.TruncateInputTokens,
+		ep.ReturnOptions,
+	)
+}

--- a/pkg/models/embedding_option.go
+++ b/pkg/models/embedding_option.go
@@ -14,10 +14,6 @@ type EmbeddingReturnOptions struct {
 }
 
 func WithEmbeddingTruncateInputTokens(truncateInputTokens uint) EmbeddingOption {
-	if truncateInputTokens < 1 {
-		panic("TruncateInputTokens must be greater or equal to 1")
-	}
-
 	return func(opts *EmbeddingOptions) {
 		opts.TruncateInputTokens = &truncateInputTokens
 	}

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 )
 
@@ -235,19 +234,4 @@ func (m *Client) generateTextStreamRequest(payload GenerateTextPayload) (<-chan 
 	}()
 
 	return dataChan, nil
-}
-
-func (m *Client) generateUrlFromEndpoint(endpoint string) string {
-	params := url.Values{
-		"version": {m.apiVersion},
-	}
-
-	generateTextURL := url.URL{
-		Scheme:   "https",
-		Host:     m.url,
-		Path:     endpoint,
-		RawQuery: params.Encode(),
-	}
-
-	return generateTextURL.String()
 }


### PR DESCRIPTION
# Add Watsonx.ai Embeddings

Issue #9

## Changes made

### Created embedding.go and embedding_option.go

Enabled two methods, following the Python SKD,
- `EmbedQuery` (single query/text to embed)
- `EmbedDocuments` (multiple queries/texts to embed)

The embedding options functional builder is followed by the prefix `WithEmbedding` to avoid collisions or confusion with the Chat (Generate) options. (Maybe is a good idea to add the `Chat` prefix to the generate options to maintain naming conventions)

### Moved the method`generateUrlFromEndpoint`

As this method is used by the embeddings as well, I believe its better to place this helper method in the `client.go` rather than in the `generate.go`

### Updated README.md

Added examples of the embedding methods

## Tests

Created a new file `test_utils.go` to keep common utility methods between all tests files such as the `getClient`

Created a `embedding_test.go` to tests embedding new feature with and without options


