### PR TITLE
Feature: add retry strategy

### DIFF
--- a/pkg/internal/tests/models/retry_test.go
+++ b/pkg/internal/tests/models/retry_test.go
@@ -2,12 +2,13 @@ package test
 
 import (
 	"encoding/json"
-	wx "github.com/IBM/watsonx-go/pkg/models"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	wx "github.com/IBM/watsonx-go/pkg/models"
 )
 
 // TestRetryWithSuccessOnFirstRequest tests the retry mechanism with a server that always returns a 200 status code.
@@ -39,7 +40,6 @@ func TestRetryWithSuccessOnFirstRequest(t *testing.T) {
 			log.Printf("Retrying request after error: %v", err)
 		}),
 	)
-	defer resp.Body.Close()
 
 	if err != nil {
 		t.Errorf("Expected nil, got error: %v", err)
@@ -49,6 +49,7 @@ func TestRetryWithSuccessOnFirstRequest(t *testing.T) {
 		t.Errorf("Expected 0 retries, but got %d", retryCount)
 	}
 
+	defer resp.Body.Close()
 	var response ResponseType
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		t.Errorf("Failed to unmarshal response body: %v", err)

--- a/pkg/internal/tests/models/retry_test.go
+++ b/pkg/internal/tests/models/retry_test.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	wx "github.com/IBM/watsonx-go/pkg/models"
+)
+
+// TestRetryWithSuccessOnFirstRequest tests the retry mechanism with a server that always returns a 200 status code.
+func TestRetryWithSuccessOnFirstRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var retryCount uint = 0
+	var expectedRetries uint = 0
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/success")
+	}
+
+	err := wx.Retry(
+		sendRequest,
+		wx.WithOnRetry(func(n uint, err error) {
+			retryCount = n
+			log.Printf("Retrying request after error: %v", err)
+		}),
+	)
+
+	if err != nil {
+		t.Errorf("Expected nil, got error: %v", err)
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 0 retries, but got %d", retryCount)
+	}
+}
+
+// TestRetryWithNoSuccessStatusOnAnyRequest tests the retry mechanism with a server that always returns a 429 status code.
+func TestRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
+	// mock server that always returns too many requests status
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	var backoffTime = 2 * time.Second
+	var retryCount uint = 0
+	var expectedRetries uint = 3
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/notfound")
+	}
+
+	startTime := time.Now()
+
+	err := wx.Retry(
+		sendRequest,
+		wx.WithBackoff(backoffTime),
+		wx.WithOnRetry(func(n uint, err error) {
+			retryCount = n
+			log.Printf("Retrying request after error: %v", err)
+		}),
+	)
+
+	endTime := time.Now()
+
+	elapsedTime := endTime.Sub(startTime)
+	expectedMinimumTime := backoffTime * time.Duration(expectedRetries)
+
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 3 retries, but got %d", retryCount)
+	}
+
+	if elapsedTime < expectedMinimumTime {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+}

--- a/pkg/models/client.go
+++ b/pkg/models/client.go
@@ -3,7 +3,6 @@ package models
 import (
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 )
@@ -62,7 +61,7 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		apiKey:    opts.apiKey,
 		projectID: opts.projectID,
 
-		httpClient: &http.Client{},
+		httpClient: NewHttpClient(),
 	}
 
 	err := m.RefreshToken()

--- a/pkg/models/embedding.go
+++ b/pkg/models/embedding.go
@@ -90,20 +90,15 @@ func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingRe
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+m.token.value)
 
-	resp, err := Retry(
-		func() (*http.Response, error) {
-			return m.httpClient.Do(req)
-		},
-		WithMaxJitter(100*time.Millisecond),
-	)
+	res, err := m.httpClient.DoWithRetry(req)
 	if err != nil {
 		return embeddingResponse{}, err
 	}
-	defer resp.Body.Close()
+	defer res.Body.Close()
 
 	var embeddingRes embeddingResponse
 
-	if err := json.NewDecoder(resp.Body).Decode(&embeddingRes); err != nil {
+	if err := json.NewDecoder(res.Body).Decode(&embeddingRes); err != nil {
 		return embeddingResponse{}, err
 	}
 

--- a/pkg/models/embedding.go
+++ b/pkg/models/embedding.go
@@ -87,7 +87,7 @@ func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingRe
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+m.token.value)
 
-	body, err := Retry(
+	resp, err := Retry(
 		func() (*http.Response, error) {
 			return m.httpClient.Do(req)
 		},
@@ -96,10 +96,11 @@ func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingRe
 	if err != nil {
 		return embeddingResponse{}, err
 	}
+	defer resp.Body.Close()
 
 	var embeddingRes embeddingResponse
 
-	if err := json.Unmarshal(body, &embeddingRes); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&embeddingRes); err != nil {
 		return embeddingResponse{}, err
 	}
 

--- a/pkg/models/embedding.go
+++ b/pkg/models/embedding.go
@@ -83,6 +83,9 @@ func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingRe
 	}
 
 	req, err := http.NewRequest(http.MethodPost, embeddingUrl, bytes.NewBuffer(payloadJSON))
+	if err != nil {
+		return embeddingResponse{}, err
+	}
 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+m.token.value)

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"strings"
-	"time"
 )
 
 const (
@@ -104,13 +103,7 @@ func (m *Client) generateTextRequest(payload GenerateTextPayload) (generateTextR
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+m.token.value)
 
-	res, err := Retry(
-		func() (*http.Response, error) {
-			return m.httpClient.Do(req)
-		},
-		WithMaxJitter(100*time.Millisecond),
-	)
-
+	res, err := m.httpClient.DoWithRetry(req)
 	if err != nil {
 		return generateTextResponse{}, err
 	}
@@ -192,13 +185,7 @@ func (m *Client) generateTextStreamRequest(payload GenerateTextPayload) (<-chan 
 		req.Header.Set("Authorization", "Bearer "+m.token.value)
 		req.Header.Set("Accept", "text/event-stream")
 
-		res, err := Retry(
-			func() (*http.Response, error) {
-				return m.httpClient.Do(req)
-			},
-			WithMaxJitter(100*time.Millisecond),
-		)
-
+		res, err := m.httpClient.DoWithRetry(req)
 		if err != nil {
 			log.Println("error making request: ", err)
 			return

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -5,11 +5,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"strings"
+	"time"
 )
 
 const (
@@ -105,19 +104,15 @@ func (m *Client) generateTextRequest(payload GenerateTextPayload) (generateTextR
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+m.token.value)
 
-	res, err := m.httpClient.Do(req)
+	res, err := Retry(
+		func() (*http.Response, error) {
+			return m.httpClient.Do(req)
+		},
+		WithMaxJitter(100*time.Millisecond),
+	)
+
 	if err != nil {
 		return generateTextResponse{}, err
-	}
-
-	statusCode := res.StatusCode
-
-	if statusCode < 200 || statusCode >= 300 {
-		body, err := io.ReadAll(res.Body)
-		if err != nil {
-			return generateTextResponse{}, fmt.Errorf("request failed with status code %d", statusCode)
-		}
-		return generateTextResponse{}, fmt.Errorf("request failed with status code %d and error %s", statusCode, body)
 	}
 	defer res.Body.Close()
 
@@ -197,23 +192,19 @@ func (m *Client) generateTextStreamRequest(payload GenerateTextPayload) (<-chan 
 		req.Header.Set("Authorization", "Bearer "+m.token.value)
 		req.Header.Set("Accept", "text/event-stream")
 
-		res, err := m.httpClient.Do(req)
+		res, err := Retry(
+			func() (*http.Response, error) {
+				return m.httpClient.Do(req)
+			},
+			WithMaxJitter(100*time.Millisecond),
+		)
+
 		if err != nil {
 			log.Println("error making request: ", err)
 			return
 		}
+
 		defer res.Body.Close()
-
-		if res.StatusCode != http.StatusOK {
-			body, err := io.ReadAll(res.Body)
-			if err != nil {
-				log.Printf("request failed with status code %d", res.StatusCode)
-			} else {
-				log.Printf("request failed with status code %d and error %s", res.StatusCode, body)
-			}
-			return
-		}
-
 		scanner := bufio.NewScanner(res.Body)
 		for scanner.Scan() {
 			line := scanner.Text()

--- a/pkg/models/retry.go
+++ b/pkg/models/retry.go
@@ -144,10 +144,3 @@ func WithRetryIf(retryIf RetryIfFunc) RetryOption {
 		cfg.retryIf = retryIf
 	}
 }
-
-// WithContext sets the context for the retry configuration.
-func WithContext(ctx context.Context) RetryOption {
-	return func(cfg *RetryConfig) {
-		cfg.context = ctx
-	}
-}

--- a/pkg/models/retry.go
+++ b/pkg/models/retry.go
@@ -138,3 +138,29 @@ func WithRetryIf(retryIf RetryIfFunc) RetryOption {
 		cfg.retryIf = retryIf
 	}
 }
+
+// Custom wrapper for http.Client that implements the Doer interface.
+// - Do
+// - DoWithRetry
+type HttpClient struct {
+	httpClient *http.Client
+}
+
+func NewHttpClient() *HttpClient {
+	return &HttpClient{
+		httpClient: &http.Client{},
+	}
+}
+
+func (c *HttpClient) Do(req *http.Request) (*http.Response, error) {
+	return c.httpClient.Do(req)
+}
+
+func (c *HttpClient) DoWithRetry(req *http.Request) (*http.Response, error) {
+	return Retry(
+		func() (*http.Response, error) {
+			return c.httpClient.Do(req)
+		},
+		WithMaxJitter(time.Second),
+	)
+}

--- a/pkg/models/retry.go
+++ b/pkg/models/retry.go
@@ -45,7 +45,7 @@ func newDefaultRetryConfig() *RetryConfig {
 	return &RetryConfig{
 		retries:   3,
 		backoff:   1 * time.Second,
-		maxJitter: 0 * time.Second,                            // no jitter by default
+		maxJitter: 1 * time.Second,
 		onRetry:   func(n uint, err error) {},                 // no-op onRetry by default
 		retryIf:   func(err error) bool { return err != nil }, // retry on any error by default
 		timer:     &timerImpl{},
@@ -161,6 +161,5 @@ func (c *HttpClient) DoWithRetry(req *http.Request) (*http.Response, error) {
 		func() (*http.Response, error) {
 			return c.httpClient.Do(req)
 		},
-		WithMaxJitter(time.Second),
 	)
 }

--- a/pkg/models/retry.go
+++ b/pkg/models/retry.go
@@ -3,7 +3,6 @@ package models
 import (
 	"context"
 	"errors"
-	"io"
 	"math/rand"
 	"net/http"
 	"time"
@@ -58,7 +57,7 @@ func newDefaultRetryConfig() *RetryConfig {
 type RetryableFuncWithResponse func() (*http.Response, error)
 
 // Retry retries the provided retryableFunc according to the retry configuration options.
-func Retry(retryableFunc RetryableFuncWithResponse, options ...RetryOption) ([]byte, error) {
+func Retry(retryableFunc RetryableFuncWithResponse, options ...RetryOption) (*http.Response, error) {
 	opts := newDefaultRetryConfig()
 
 	for _, opt := range options {
@@ -75,12 +74,7 @@ func Retry(retryableFunc RetryableFuncWithResponse, options ...RetryOption) ([]b
 
 		resp, err := retryableFunc()
 		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
-			defer resp.Body.Close()
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return nil, err
-			}
-			return body, nil
+			return resp, nil
 		}
 
 		if err == nil && resp != nil {

--- a/pkg/models/retry.go
+++ b/pkg/models/retry.go
@@ -1,0 +1,141 @@
+package models
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+type OnRetryFunc func(attempt uint, err error)
+
+// Timer to track time for a retry
+type Timer interface {
+	After(time.Duration) <-chan time.Time
+}
+
+type RetryIfFunc func(error) bool
+
+type RetryConfig struct {
+	retries   uint
+	backoff   time.Duration
+	maxJitter time.Duration
+	onRetry   OnRetryFunc
+	retryIf   RetryIfFunc
+	timer     Timer
+	context   context.Context
+}
+
+type RetryOption func(*RetryConfig)
+
+type timerImpl struct{}
+
+func (t timerImpl) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+func newDefaultRetryConfig() *RetryConfig {
+	return &RetryConfig{
+		retries:   3,
+		backoff:   1 * time.Second,
+		maxJitter: 0 * time.Second, // no jitter by default
+		onRetry:   func(n uint, err error) {},
+		retryIf:   func(err error) bool { return err != nil }, // default to retry on any error
+		timer:     &timerImpl{},
+		context:   context.Background(),
+	}
+}
+
+type RetryableFunc func() error
+
+type RetryableFuncWithResponse func() (*http.Response, error)
+
+// Retry retries the provided retryableFunc according to the retry configuration options.
+func Retry(retryableFunc RetryableFuncWithResponse, options ...RetryOption) error {
+	opts := newDefaultRetryConfig()
+
+	for _, opt := range options {
+		if opt != nil {
+			opt(opts)
+		}
+	}
+
+	var lastErr error
+	for n := uint(0); n < opts.retries; n++ {
+		if err := opts.context.Err(); err != nil {
+			return err
+		}
+
+		resp, err := retryableFunc()
+		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		if err == nil {
+			err = errors.New(resp.Status)
+		}
+
+		if !opts.retryIf(err) {
+			return err
+		}
+
+		lastErr = err
+		opts.onRetry(n+1, err)
+
+		backoffDuration := opts.backoff
+		if opts.maxJitter > 0 {
+			jitter := time.Duration(rand.Int63n(int64(opts.maxJitter)))
+			backoffDuration += jitter
+		}
+
+		select {
+		case <-opts.timer.After(backoffDuration):
+		case <-opts.context.Done():
+			return opts.context.Err()
+		}
+	}
+
+	return lastErr
+}
+
+// WithRetries sets the number of retries for the retry configuration.
+func WithRetries(retries uint) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.retries = retries
+	}
+}
+
+// WithBackoff sets the backoff duration between retries.
+func WithBackoff(backoff time.Duration) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.backoff = backoff
+	}
+}
+
+// WithMaxJitter sets the maximum jitter duration to add to the backoff.
+func WithMaxJitter(maxJitter time.Duration) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.maxJitter = maxJitter
+	}
+}
+
+// WithOnRetry sets the callback function to execute on each retry.
+func WithOnRetry(onRetry OnRetryFunc) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.onRetry = onRetry
+	}
+}
+
+// WithRetryIf sets the condition to determine whether to retry based on the error.
+func WithRetryIf(retryIf RetryIfFunc) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.retryIf = retryIf
+	}
+}
+
+// WithContext sets the context for the retry configuration.
+func WithContext(ctx context.Context) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.context = ctx
+	}
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -32,4 +32,5 @@ const (
 
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
+	DoWithRetry(req *http.Request) (*http.Response, error)
 }


### PR DESCRIPTION
# Add Flexible Retry Mechanism with Configurable Backoff and Jitter
Issue #16 

## Description:

This PR introduces a flexible retry mechanism for HTTP requests with the following key features:

- Configurable Retries: Allows setting the number of retry attempts with the WithRetries option.
- Backoff with Optional Jitter: Implements a backoff strategy with an optional jitter to prevent thundering herd problems using the WithBackoff and WithMaxJitter options.
- Custom Retry Condition: Users can define custom conditions to determine whether a retry should occur based on the error using the WithRetryIf option.
- Retry Callback: A callback function can be provided to execute custom logic after each retry attempt using the WithOnRetry option.
- Context Support: The retry process can be canceled or timed out using a context, ensuring the retries adhere to the overall request's lifecycle.

## Code Changes:

- Added a Retry function that accepts a RetryableFuncWithResponse and a variadic list of RetryOption to configure retries.
- Introduced a RetryConfig struct to hold retry configurations.
- Defined a Timer interface to abstract time-based operations for retries, allowing easier testing and customization.
- Provided several RetryOption functions to customize retry behavior (WithRetries, WithBackoff, WithMaxJitter, WithOnRetry, WithRetryIf).
- Used this lightweight retry module in the `generate` and `embedding` features.

## Tests:

Ensure to include or add unit tests to cover various retry scenarios, including:
- Success scenario (200 Code)
- Failure scenario (429 Code | too many requests)