### PR TITLE
Handle retries without returning errors for non-network errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .env
+
+# For now ignore local VS Code settings
+.vscode/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,24 @@
+version: 2
+
+# See https://golangci-lint.run/usage/configuration/ for all options
+
+run:
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - unused
+    - ineffassign
+    - misspell
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  exclude-use-default: false

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# Default target
+default: build
+
+# Build the application
+.PHONY: build
+
+build:
+	go build ./...
+
+# Test target to run all tests in the project
+.PHONY: test
+
+test: build
+	go test ./... -v
+
+# Lint target to run the linter
+.PHONY: lint
+
+lint:
+	golangci-lint run
+
+# Run linter with fixes
+.PHONY: lint-fix
+
+lint-fix:
+	golangci-lint run --fix
+
+# Check Go code formatting without modifying files
+.PHONY: fmt-check
+
+fmt-check:
+	@echo "Checking Go formatting..."
+	@if [ -n "$$(gofmt -l .)" ]; then \
+		echo "The following files need formatting:"; \
+		gofmt -l .; \
+		exit 1; \
+	fi
+	@if [ -n "$$(goimports -l .)" ]; then \
+		echo "The following files need import formatting:"; \
+		goimports -l .; \
+		exit 1; \
+	fi
+	@echo "All files are properly formatted!"
+
+# Format Go code
+.PHONY: fmt
+
+fmt:
+	gofmt -w .
+	goimports -w .
+
+# Install the application
+.PHONY: install
+
+install: build
+	go install
+
+# Check for Go modules updates
+.PHONY: update
+
+update:
+	go get -u ./...
+	go mod tidy
+
+
+# Ensure pre-commit hook is executable
+.PHONY: config-pre-commit
+
+config-pre-commit:
+	@echo "Setting up pre-commit hook..."
+	git config --local core.hooksPath .githooks/
+
+# Pre-commit checks (format, lint, test)
+.PHONY: pre-commit
+
+pre-commit: fmt lint test
+	@echo "Pre-commit checks passed!"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Or pass in the required secrets directly:
 
 ```go
 client, err := wx.NewClient(
+  wx.WithClientRetryConfig(wx.NewRetryConfig(
+    wx.WithReturnHTTPStatusAsErr(false)),
+  ),
   wx.WithWatsonxAPIKey(apiKey),
   wx.WithWatsonxProjectID(projectID),
 )
@@ -44,7 +47,7 @@ Generation:
 
 ```go
 result, _ := client.GenerateText(
-  "meta-llama/llama-3-1-8b-instruct",
+  "meta-llama/llama-3-3-70b-instruct",
   "Hi, who are you?",
   wx.WithTemperature(0.4),
   wx.WithMaxNewTokens(512),
@@ -57,7 +60,7 @@ Stream Generation:
 
 ```go
 dataChan, _ := client.GenerateTextStream(
-  "meta-llama/llama-3-1-8b-instruct",
+  "meta-llama/llama-3-3-70b-instruct",
   "Hi, who are you?",
   wx.WithTemperature(0.4),
   wx.WithMaxNewTokens(512),
@@ -142,6 +145,9 @@ Specify the Watsonx URL and IAM endpoint through the parameters of the NewClient
 
 ```go
 client, err := wx.NewClient(
+  	wx.WithClientRetryConfig(wx.NewRetryConfig(
+			wx.WithReturnHTTPStatusAsErr(false)),
+		),
   wx.WithURL("us-south.ml.test.cloud.ibm.com"),
   wx.WithIAM("iam.test.cloud.ibm.com"),
   wx.WithWatsonxAPIKey(apiKey),

--- a/pkg/internal/tests/models/embedding_test.go
+++ b/pkg/internal/tests/models/embedding_test.go
@@ -1,9 +1,10 @@
 package test
 
 import (
-	wx "github.com/IBM/watsonx-go/pkg/models"
 	"reflect"
 	"testing"
+
+	wx "github.com/IBM/watsonx-go/pkg/models"
 )
 
 const (

--- a/pkg/internal/tests/models/embedding_test.go
+++ b/pkg/internal/tests/models/embedding_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -8,8 +9,9 @@ import (
 )
 
 const (
-	EmbeddingModelId        = "ibm/slate-30m-english-rtrvr"
-	EmbeddingModelDimension = 384
+	EmbeddingModelId                   = "ibm/slate-30m-english-rtrvr"
+	modelLlama3DoesNotSupportEmbedding = "meta-llama/llama-3-3-70b-instruct"
+	EmbeddingModelDimension            = 384
 )
 
 func TestEmbeddingSingleQuery(t *testing.T) {
@@ -79,7 +81,7 @@ func TestEmbeddingSingleQueryWithOptions(t *testing.T) {
 	}
 
 	if reflect.DeepEqual(response.Results[0].Embedding, responseNoOptions.Results[0].Embedding) {
-		t.Fatalf("Expected different embeddings with and without options, but got the same")
+		t.Fatal("Expected different embeddings with and without options, but got the same")
 	}
 }
 
@@ -114,5 +116,30 @@ func TestEmbeddingMultipleQueries(t *testing.T) {
 
 	if response.Model != EmbeddingModelId {
 		t.Fatalf("Expected model to be %s, but got %s", EmbeddingModelId, response.Model)
+	}
+}
+
+func TestEmbeddingModelDoesNotSupportEmbedding(t *testing.T) {
+	client := getClient(t)
+
+	text := "Hello, world!"
+
+	_, err := client.EmbedQuery(modelLlama3DoesNotSupportEmbedding, text)
+
+	if err == nil {
+		t.Fatal("Expected error for invalid model but got nil")
+	}
+
+	errorMessage := parseResponseErrMessage(t, err)
+	if errorMessage == nil {
+		t.Fatalf("Expected JSON error message, but got: %v", err)
+	}
+
+	if errorMessage.StatusCode != 400 {
+		t.Fatalf("Expected status code 400, but got: %d", errorMessage.StatusCode)
+	}
+	expectedErrText := fmt.Sprintf("Model '%s' does not support function 'function_embedding'", modelLlama3DoesNotSupportEmbedding)
+	if len(errorMessage.Errors) == 0 || errorMessage.Errors[0].Message != expectedErrText {
+		t.Fatalf("Expected error message to be %s, but got: %v", expectedErrText, errorMessage.Errors[0].Message)
 	}
 }

--- a/pkg/internal/tests/models/generate_test.go
+++ b/pkg/internal/tests/models/generate_test.go
@@ -7,6 +7,11 @@ import (
 	wx "github.com/IBM/watsonx-go/pkg/models"
 )
 
+const (
+	modelLlama3  = "meta-llama/llama-3-3-70b-instruct"
+	modelFlanUL2 = "google/flan-ul2"
+)
+
 func TestClientCreationWithEnvVars(t *testing.T) {
 	_, err := wx.NewClient()
 
@@ -26,6 +31,9 @@ func TestClientCreationWithPassing(t *testing.T) {
 	}
 
 	_, err := wx.NewClient(
+		wx.WithClientRetryConfig(wx.NewRetryConfig(
+			wx.WithReturnHTTPStatusAsErr(false),
+		)),
 		wx.WithWatsonxAPIKey(apiKey),
 		wx.WithWatsonxProjectID(projectID),
 	)
@@ -51,7 +59,7 @@ func TestNilOptions(t *testing.T) {
 	client := getClient(t)
 
 	_, err := client.GenerateText(
-		"meta-llama/llama-3-70b-instruct",
+		modelLlama3,
 		"What day is it?",
 		nil,
 	)
@@ -64,7 +72,7 @@ func TestValidPrompt(t *testing.T) {
 	client := getClient(t)
 
 	_, err := client.GenerateText(
-		"meta-llama/llama-3-70b-instruct",
+		modelLlama3,
 		"Test prompt",
 	)
 	if err != nil {
@@ -76,7 +84,7 @@ func TestGenerateText(t *testing.T) {
 	client := getClient(t)
 
 	result, err := client.GenerateText(
-		"meta-llama/llama-3-70b-instruct",
+		modelLlama3,
 		"Hi, who are you?",
 		wx.WithTemperature(0.9),
 		wx.WithTopP(.5),
@@ -95,7 +103,7 @@ func TestGenerateTextStream(t *testing.T) {
 	client := getClient(t)
 
 	dataChan, err := client.GenerateTextStream(
-		"google/flan-ul2",
+		modelFlanUL2,
 		"Hi, who are you?",
 		wx.WithTemperature(0.9),
 		wx.WithTopP(.5),
@@ -126,7 +134,7 @@ func TestGenerateTextWithNoPrompt(t *testing.T) {
 	client := getClient(t)
 
 	dataChan, err := client.GenerateTextStream(
-		"google/flan-ul2",
+		modelFlanUL2,
 		"",
 		wx.WithTemperature(0.9),
 		wx.WithTopP(.5),
@@ -158,7 +166,7 @@ func TestGenerateTextWithNilOptions(t *testing.T) {
 	client := getClient(t)
 
 	result, err := client.GenerateText(
-		"meta-llama/llama-3-70b-instruct",
+		modelLlama3,
 		"Who are you?",
 		nil,
 	)

--- a/pkg/internal/tests/models/retry_test.go
+++ b/pkg/internal/tests/models/retry_test.go
@@ -35,10 +35,12 @@ func TestRetryWithSuccessOnFirstRequest(t *testing.T) {
 
 	resp, err := wx.Retry(
 		sendRequest,
-		wx.WithOnRetry(func(n uint, err error) {
-			retryCount = n
-			log.Printf("Retrying request after error: %v", err)
-		}),
+		wx.NewRetryConfig(
+			wx.WithOnRetry(func(n uint, err error) {
+				retryCount = n
+				log.Printf("Retrying request after error: %v", err)
+			}),
+		),
 	)
 
 	if err != nil {
@@ -60,8 +62,8 @@ func TestRetryWithSuccessOnFirstRequest(t *testing.T) {
 	}
 }
 
-// TestRetryWithNoSuccessStatusOnAnyRequest tests the retry mechanism with a server that always returns a 429 status code.
-func TestRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
+// TestLegacyRetryWithNoSuccessStatusOnAnyRequest tests the retry mechanism with a server that always returns a 429 status code.
+func TestLegacyRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
@@ -79,11 +81,13 @@ func TestRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
 
 	resp, err := wx.Retry(
 		sendRequest,
-		wx.WithBackoff(backoffTime),
-		wx.WithOnRetry(func(n uint, err error) {
-			retryCount = n
-			log.Printf("Retrying request after error: %v", err)
-		}),
+		wx.NewRetryConfig(
+			wx.WithBackoff(backoffTime),
+			wx.WithOnRetry(func(n uint, err error) {
+				retryCount = n
+				log.Printf("Retrying request after error: %v", err)
+			}),
+		),
 	)
 
 	endTime := time.Now()
@@ -98,6 +102,75 @@ func TestRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
 	if resp != nil {
 		defer resp.Body.Close()
 		t.Errorf("Expected nil response, got %v", resp.Body)
+	}
+
+	if retryCount != expectedRetries {
+		t.Errorf("Expected 3 retries, but got %d", retryCount)
+	}
+
+	if elapsedTime < expectedMinimumTime {
+		t.Errorf("Expected minimum time of %v, but got %v", expectedMinimumTime, elapsedTime)
+	}
+}
+
+// TestRetryWithNoSuccessStatusOnAnyRequest tests the retry mechanism with a server that always returns a 429 status code.
+func TestRetryWithNoSuccessStatusOnAnyRequest(t *testing.T) {
+	expectedStatusCode := http.StatusTooManyRequests
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(expectedStatusCode)
+	}))
+	defer server.Close()
+
+	var backoffTime = 2 * time.Second
+	var retryCount uint = 0
+	var expectedRetries uint = 3
+
+	sendRequest := func() (*http.Response, error) {
+		return http.Get(server.URL + "/notfound")
+	}
+
+	startTime := time.Now()
+
+	resp, err := wx.Retry(
+		sendRequest,
+		wx.NewRetryConfig(
+			wx.WithReturnHTTPStatusAsErr(false), // Use new behavior: only return actual network errors
+			wx.WithBackoff(backoffTime),
+			wx.WithOnRetryV2(func(n uint, resp *http.Response, err error) {
+				retryCount = n
+				if err != nil {
+					t.Errorf("In OnRetry, expected nil, got error: %v", err)
+				}
+
+				if resp == nil {
+					t.Errorf("In OnRetry, expected non-nil response, got nil")
+				}
+
+				if resp != nil && resp.StatusCode != expectedStatusCode {
+					t.Errorf("Expected status code %d, got %d", expectedStatusCode, resp.StatusCode)
+				}
+
+				log.Printf("Retrying request after response with status code: %d", resp.StatusCode)
+			}),
+		),
+	)
+
+	endTime := time.Now()
+
+	elapsedTime := endTime.Sub(startTime)
+	expectedMinimumTime := backoffTime * time.Duration(expectedRetries)
+
+	if err != nil {
+		t.Errorf("Expected nil, got error: %v", err)
+	}
+
+	if resp == nil {
+		t.Errorf("Expected non-nil response, got nil")
+	}
+
+	if resp != nil && resp.StatusCode != expectedStatusCode {
+		t.Errorf("Expected status code %d, got %d", expectedStatusCode, resp.StatusCode)
 	}
 
 	if retryCount != expectedRetries {

--- a/pkg/internal/tests/models/test_utils.go
+++ b/pkg/internal/tests/models/test_utils.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -29,4 +30,48 @@ func getClient(t *testing.T) *wx.Client {
 	}
 
 	return client
+}
+
+func getClientWithLegacyRetry(t *testing.T) *wx.Client {
+	apiKey, projectID := os.Getenv(wx.WatsonxAPIKeyEnvVarName), os.Getenv(wx.WatsonxProjectIDEnvVarName)
+
+	if apiKey == "" {
+		t.Fatal("No watsonx API key provided")
+	}
+	if projectID == "" {
+		t.Fatal("No watsonx project ID provided")
+	}
+
+	client, err := wx.NewClient(
+		wx.WithWatsonxAPIKey(apiKey),
+		wx.WithWatsonxProjectID(projectID),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create client for testing. Error: %v", err)
+	}
+
+	return client
+}
+
+type WatsonxError struct {
+	Errors []struct {
+		Code     string `json:"code"`
+		Message  string `json:"message"`
+		MoreInfo string `json:"more_info"`
+	} `json:"errors"`
+	Trace      string `json:"trace"`
+	StatusCode int    `json:"status_code"`
+}
+
+func parseResponseErrMessage(t *testing.T, err error) *WatsonxError {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	var wxErr WatsonxError
+	if err := json.Unmarshal([]byte(msg), &wxErr); err != nil {
+		t.Logf("Failed to unmarshal error JSON: %v", err)
+		return nil
+	}
+	return &wxErr
 }

--- a/pkg/internal/tests/models/test_utils.go
+++ b/pkg/internal/tests/models/test_utils.go
@@ -1,9 +1,10 @@
 package test
 
 import (
-	wx "github.com/IBM/watsonx-go/pkg/models"
 	"os"
 	"testing"
+
+	wx "github.com/IBM/watsonx-go/pkg/models"
 )
 
 func getClient(t *testing.T) *wx.Client {
@@ -17,6 +18,9 @@ func getClient(t *testing.T) *wx.Client {
 	}
 
 	client, err := wx.NewClient(
+		wx.WithClientRetryConfig(wx.NewRetryConfig(
+			wx.WithReturnHTTPStatusAsErr(false)),
+		),
 		wx.WithWatsonxAPIKey(apiKey),
 		wx.WithWatsonxProjectID(projectID),
 	)

--- a/pkg/models/client.go
+++ b/pkg/models/client.go
@@ -26,7 +26,7 @@ type Client struct {
 
 func NewClient(options ...ClientOption) (*Client, error) {
 
-	opts := defaulClientOptions()
+	opts := defaultClientOptions()
 	for _, opt := range options {
 		if opt != nil {
 			opt(opts)
@@ -61,7 +61,9 @@ func NewClient(options ...ClientOption) (*Client, error) {
 		apiKey:    opts.apiKey,
 		projectID: opts.projectID,
 
-		httpClient: NewHttpClient(),
+		httpClient: NewHttpClient(
+			WithRetryConfig(opts.retryConfig),
+		),
 	}
 
 	err := m.RefreshToken()
@@ -110,7 +112,7 @@ func buildBaseURL(region IBMCloudRegion) string {
 	return fmt.Sprintf(BaseURLFormatStr, region)
 }
 
-func defaulClientOptions() *ClientOptions {
+func defaultClientOptions() *ClientOptions {
 	return &ClientOptions{
 		URL:        os.Getenv(WatsonxURLEnvVarName),
 		IAM:        os.Getenv(WatsonxIAMEnvVarName),
@@ -119,5 +121,7 @@ func defaulClientOptions() *ClientOptions {
 
 		apiKey:    os.Getenv(WatsonxAPIKeyEnvVarName),
 		projectID: os.Getenv(WatsonxProjectIDEnvVarName),
+
+		retryConfig: NewDefaultRetryConfig(),
 	}
 }

--- a/pkg/models/client_option.go
+++ b/pkg/models/client_option.go
@@ -10,6 +10,8 @@ type ClientOptions struct {
 
 	apiKey    WatsonxAPIKey
 	projectID WatsonxProjectID
+
+	retryConfig *RetryConfig
 }
 
 func WithURL(url string) ClientOption {
@@ -45,5 +47,11 @@ func WithWatsonxAPIKey(watsonxAPIKey WatsonxAPIKey) ClientOption {
 func WithWatsonxProjectID(projectID WatsonxProjectID) ClientOption {
 	return func(o *ClientOptions) {
 		o.projectID = projectID
+	}
+}
+
+func WithClientRetryConfig(retryConfig *RetryConfig) ClientOption {
+	return func(o *ClientOptions) {
+		o.retryConfig = retryConfig
 	}
 }

--- a/pkg/models/embedding.go
+++ b/pkg/models/embedding.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"time"
 )
@@ -90,11 +89,6 @@ func (m *Client) generateEmbeddingRequest(payload EmbeddingPayload) (embeddingRe
 	req, err := http.NewRequest(http.MethodPost, embeddingUrl, bytes.NewReader(payloadJSON))
 	if err != nil {
 		return embeddingResponse{}, err
-	}
-
-	// Enable request body to be recreated for retries
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(payloadJSON)), nil
 	}
 
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/models/generate.go
+++ b/pkg/models/generate.go
@@ -77,7 +77,7 @@ func (m *Client) GenerateText(model, prompt string, options ...GenerateOption) (
 	}
 
 	if len(response.Results) == 0 {
-		return GenerateTextResult{}, errors.New("no result recieved")
+		return GenerateTextResult{}, errors.New("no result received")
 	}
 
 	result := response.Results[0]

--- a/pkg/models/iam.go
+++ b/pkg/models/iam.go
@@ -32,9 +32,9 @@ func GenerateToken(client Doer, watsonxApiKey WatsonxAPIKey, iamCloudHost string
 	payload := strings.NewReader(values.Encode())
 
 	iamTokenEndpoint := url.URL{
-		Scheme:   "https",
-		Host:     iamCloudHost,
-		Path:     TokenPath,
+		Scheme: "https",
+		Host:   iamCloudHost,
+		Path:   TokenPath,
 	}
 	req, err := http.NewRequest(http.MethodPost, iamTokenEndpoint.String(), payload)
 	if err != nil {

--- a/pkg/models/retry.go
+++ b/pkg/models/retry.go
@@ -11,6 +11,9 @@ import (
 // OnRetryFunc is a function type that is called on each retry attempt.
 type OnRetryFunc func(attempt uint, err error)
 
+// OnRetryV2Func is a function type that is called on each retry attempt with response.
+type OnRetryV2Func func(attempt uint, resp *http.Response, err error)
+
 // Timer interface to abstract time-based operations for retries.
 type Timer interface {
 	After(time.Duration) <-chan time.Time
@@ -19,15 +22,21 @@ type Timer interface {
 // RetryIfFunc determines whether a retry should be attempted based on the error.
 type RetryIfFunc func(error) bool
 
+// RetryIfFuncV2 determines whether a retry should be attempted based on the response.
+type RetryIfFuncV2 func(*http.Response, error) bool
+
 // RetryConfig contains configuration options for the retry mechanism.
 type RetryConfig struct {
-	retries   uint
-	backoff   time.Duration
-	maxJitter time.Duration
-	onRetry   OnRetryFunc
-	retryIf   RetryIfFunc
-	timer     Timer
-	context   context.Context
+	retries               uint
+	backoff               time.Duration
+	maxJitter             time.Duration
+	onRetry               OnRetryFunc   // Legacy callback for retries
+	onRetryV2             OnRetryV2Func // Callback for retries with response
+	retryIf               RetryIfFunc   // Legacy error-based retry function
+	retryIfV2             RetryIfFuncV2 // New response-based retry function
+	timer                 Timer
+	context               context.Context
+	returnHTTPStatusAsErr bool // When true, use legacy behavior: convert HTTP status to errors
 }
 
 // RetryOption is a function type for modifying RetryConfig options.
@@ -40,16 +49,43 @@ func (t timerImpl) After(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
 
-// newDefaultRetryConfig creates a default RetryConfig with sensible defaults.
-func newDefaultRetryConfig() *RetryConfig {
+// NewDefaultRetryConfig creates a default RetryConfig with sensible defaults.
+func NewDefaultRetryConfig() *RetryConfig {
 	return &RetryConfig{
 		retries:   3,
 		backoff:   1 * time.Second,
 		maxJitter: 1 * time.Second,
-		onRetry:   func(n uint, err error) {},                 // no-op onRetry by default
-		retryIf:   func(err error) bool { return err != nil }, // retry on any error by default
-		timer:     &timerImpl{},
-		context:   context.Background(),
+		onRetry:   func(n uint, err error) {},                      // no-op onRetry by default
+		onRetryV2: func(n uint, resp *http.Response, err error) {}, // no-op onRetry by default
+		retryIf:   func(err error) bool { return err != nil },      // retry on any error by default (legacy)
+		retryIfV2: func(resp *http.Response, err error) bool {
+			return err != nil || (resp != nil && resp.StatusCode >= http.StatusBadRequest)
+		}, // retry on any error or 4xx/5xx response by default (new)
+		timer:                 &timerImpl{},
+		context:               context.Background(),
+		returnHTTPStatusAsErr: true, // Legacy behavior: convert HTTP status to errors
+	}
+}
+
+func NewRetryConfig(options ...RetryOption) *RetryConfig {
+	opts := NewDefaultRetryConfig()
+
+	for _, opt := range options {
+		if opt != nil {
+			opt(opts)
+		}
+	}
+	return &RetryConfig{
+		retries:               opts.retries,
+		backoff:               opts.backoff,
+		maxJitter:             opts.maxJitter,
+		onRetry:               opts.onRetry,
+		onRetryV2:             opts.onRetryV2,
+		retryIf:               opts.retryIf,
+		retryIfV2:             opts.retryIfV2,
+		timer:                 opts.timer,
+		context:               opts.context,
+		returnHTTPStatusAsErr: opts.returnHTTPStatusAsErr,
 	}
 }
 
@@ -57,51 +93,69 @@ func newDefaultRetryConfig() *RetryConfig {
 type RetryableFuncWithResponse func() (*http.Response, error)
 
 // Retry retries the provided retryableFunc according to the retry configuration options.
-func Retry(retryableFunc RetryableFuncWithResponse, options ...RetryOption) (*http.Response, error) {
-	opts := newDefaultRetryConfig()
-
-	for _, opt := range options {
-		if opt != nil {
-			opt(opts)
-		}
-	}
-
+func Retry(retryableFunc RetryableFuncWithResponse, retryConfig *RetryConfig) (*http.Response, error) {
 	var lastErr error
-	for n := uint(0); n < opts.retries; n++ {
-		if err := opts.context.Err(); err != nil {
+	var lastResp *http.Response
+
+	for n := uint(0); n < retryConfig.retries; n++ {
+		if err := retryConfig.context.Err(); err != nil {
 			return nil, err
 		}
 
 		resp, err := retryableFunc()
+
+		// If the response is successful, return it immediately
 		if err == nil && resp != nil && resp.StatusCode == http.StatusOK {
 			return resp, nil
 		}
 
-		if err == nil && resp != nil {
-			err = errors.New(resp.Status)
-		}
-
-		if !opts.retryIf(err) {
-			return nil, err
-		}
-
+		// Store the response and error for potential return
+		lastResp = resp
 		lastErr = err
-		opts.onRetry(n+1, err)
+		statusAsErr := errors.New(resp.Status)
+		errResult := err
 
-		backoffDuration := opts.backoff
-		if opts.maxJitter > 0 {
-			jitter := time.Duration(rand.Int63n(int64(opts.maxJitter)))
+		// Determine if we should retry based on error or response
+		retryIfV1Err := err
+		shouldRetry := false
+		if err == nil && resp != nil {
+			retryIfV1Err = statusAsErr
+			// set errResult and lastErr based on behavior flag
+			if retryConfig.returnHTTPStatusAsErr {
+				errResult = statusAsErr
+				lastErr = statusAsErr
+			}
+		}
+
+		shouldRetry = retryConfig.retryIf(retryIfV1Err) || retryConfig.retryIfV2(resp, err)
+		if !shouldRetry {
+			return resp, errResult
+		}
+
+		retryConfig.onRetry(n+1, statusAsErr)
+		retryConfig.onRetryV2(n+1, resp, err)
+
+		// Apply backoff and jitter
+		backoffDuration := retryConfig.backoff
+		if retryConfig.maxJitter > 0 {
+			jitter := time.Duration(rand.Int63n(int64(retryConfig.maxJitter)))
 			backoffDuration += jitter
 		}
 
 		select {
-		case <-opts.timer.After(backoffDuration):
-		case <-opts.context.Done():
-			return nil, opts.context.Err()
+		case <-retryConfig.timer.After(backoffDuration):
+		case <-retryConfig.context.Done():
+			return nil, retryConfig.context.Err()
 		}
 	}
 
-	return nil, lastErr
+	if retryConfig.returnHTTPStatusAsErr {
+		// Legacy behavior: convert HTTP status to error if no network error
+		return nil, lastErr
+	}
+
+	// New behavior: only return actual network errors
+	return lastResp, lastErr
 }
 
 // WithRetries sets the number of retries for the retry configuration.
@@ -132,6 +186,13 @@ func WithOnRetry(onRetry OnRetryFunc) RetryOption {
 	}
 }
 
+// WithOnRetry sets the callback function to execute on each retry.
+func WithOnRetryV2(onRetry OnRetryV2Func) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.onRetryV2 = onRetry
+	}
+}
+
 // WithRetryIf sets the condition to determine whether to retry based on the error.
 func WithRetryIf(retryIf RetryIfFunc) RetryOption {
 	return func(cfg *RetryConfig) {
@@ -139,16 +200,69 @@ func WithRetryIf(retryIf RetryIfFunc) RetryOption {
 	}
 }
 
+// WithRetryIfV2 sets the condition to determine whether to retry based on the response.
+// This enables the new response-based retry logic and automatically enables the
+// new behavior flags.
+func WithRetryIfV2(retryIf RetryIfFuncV2) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.retryIf = func(err error) bool { return false } // Disable legacy retryIf
+		cfg.onRetry = func(n uint, err error) {}            // Disable legacy onRetry
+		cfg.retryIfV2 = retryIf
+		cfg.returnHTTPStatusAsErr = false // Enable new behavior by default when using V2
+	}
+}
+
+// WithReturnHTTPStatusAsErr controls the legacy behavior where HTTP status codes
+// are converted to Go errors. When enabled (true, default), HTTP status codes
+// are converted to errors (legacy behavior). When disabled (false), only actual
+// network/request errors are returned as errors, while HTTP responses (even with
+// 4xx/5xx status) return nil error (new correct behavior).
+func WithReturnHTTPStatusAsErr(enabled bool) RetryOption {
+	return func(cfg *RetryConfig) {
+		cfg.returnHTTPStatusAsErr = enabled
+	}
+}
+
 // Custom wrapper for http.Client that implements the Doer interface.
 // - Do
 // - DoWithRetry
 type HttpClient struct {
-	httpClient *http.Client
+	httpClient  *http.Client
+	retryConfig *RetryConfig
 }
 
-func NewHttpClient() *HttpClient {
+type HttpClientConfig struct {
+	retryConfig *RetryConfig
+}
+
+func newDefaultHttpClientConfig() *HttpClientConfig {
+	return &HttpClientConfig{
+		retryConfig: NewDefaultRetryConfig(),
+	}
+}
+
+// HttpClientConfigOption is a function type for modifying HttpClientConfig options.
+type HttpClientConfigOption func(*HttpClientConfig)
+
+func NewHttpClient(options ...HttpClientConfigOption) *HttpClient {
+
+	opts := newDefaultHttpClientConfig()
+
+	for _, opt := range options {
+		if opt != nil {
+			opt(opts)
+		}
+	}
+
 	return &HttpClient{
-		httpClient: &http.Client{},
+		httpClient:  &http.Client{},
+		retryConfig: opts.retryConfig,
+	}
+}
+
+func WithRetryConfig(config *RetryConfig) HttpClientConfigOption {
+	return func(cfg *HttpClientConfig) {
+		cfg.retryConfig = config
 	}
 }
 
@@ -161,5 +275,6 @@ func (c *HttpClient) DoWithRetry(req *http.Request) (*http.Response, error) {
 		func() (*http.Response, error) {
 			return c.httpClient.Do(req)
 		},
+		c.retryConfig,
 	)
 }


### PR DESCRIPTION

# Fix Retry logic to avoid loss of request body on retry and return response body on non-200 Responses:
Issue https://github.com/IBM/watsonx-go/issues/22

This PR addresses an issue in the `watsonx-go` client library where HTTP request bodies were being lost during retry attempts, causing 400 Bad Request errors from the server.

## Description
- **Root Cause**: When using `bytes.NewBuffer()` for HTTP request bodies, the buffer gets consumed on the first request attempt. On subsequent retries, the request body was empty, leading to 400 HTML formatted server errors instead of expected json http responses.
- **Impact**: All retry attempts after the first request would fail with 400 Bad Request errors, making the retry mechanism behave unexpectedly, and lose context of error response from server.
- **Additional Issues**: The existing retry logic, wraps non-200 status codes into an error and returns them as a non-nil error which causes the caller to no longer have access to the body of the http response which may contain critically useful troubleshooting information about the server error. Especially for 400 and 500 error (i.e. non-network errors), the server typically responds with helpful error, and status information.  Currently, only the status number is returned in the err and nil is returned as the response. The current behavior of wrapping the status code integer as an error and returning it to the caller also seems to be inconsistent with traditional go http.Client behavior of returning nil error and the response for the caller to handle as they see fit.

## Code Changes

### 1. Enhanced Retry Mechanism (`pkg/models/retry.go`)
- **Refactor** of the retry logic to support request body handling and allowing for nil error and non-nil response for non-200 and non-network error cases.
- **Added `req.GetBody` support**: Enables automatic request body recreation for retries (i.e. in `prepareRequest`)
- **New retry configuration options**:
  - `WithRetryIfV2()`: Response-based retry conditions (vs legacy error-based)
  - `WithOnRetryV2()`: Enhanced retry callbacks with response access
  - `WithReturnHTTPStatusAsErr()`: Controls legacy behavior of converting HTTP status to errors
  - `Retry()`: Now expectes a request parameter for better control over the request (e.g. ability to prepare request body for retry)
- **Improved error handling**: Proper separation of network errors vs HTTP response errors

### 2. Fixed Request Body Handling (`pkg/models/generate.go`, `pkg/models/embedding.go`)
- **Replaced `bytes.NewBuffer()` with `bytes.NewReader()`**: Prevents buffer consumption issues
- **Enhanced error handling**: Better HTTP status code detection and error reporting

### 3. Added Test Coverage (`pkg/internal/tests/models/generate_test.go`)
- **Added invalid parameter tests**: Validate proper error handling for bad requests
- **Added invalid model tests**: Test both new and legacy retry behaviors
- **Enhanced error validation**: Parse and validate JSON error responses
- **Improved test organization**: Better constants and helper functions

### 4. Development Tools Enhancement (`Makefile`)
- **Added `fmt-check` target**: Check code formatting without modifying files
- **Enhanced build pipeline**: Added proper dependencies between targets
- **Improved structure**: Better organization and documentation

## **Migration Notes**
- **No breaking changes**: All existing code continues to work unchanged
- **Optional enhancements**: New retry options available for advanced use cases
- **Legacy support**: Old retry behavior maintained through configuration flags

## **Files Modified**
- `pkg/models/retry.go` - Core retry mechanism improvements
- `pkg/models/generate.go` - Request body fix for text generation
- `pkg/models/embedding.go` - Request body fix for embeddings
- `pkg/internal/tests/models/generate_test.go` - Enhanced test coverage
- `Makefile` - Added formatting check capabilities

## **Externally Visible Outcome**

### GenerateText err - Before fix
```
400
```

### GenerateText err - After fix
```
{"errors":[{"code":"model_not_supported","message":"Model 'meta-llama/llama-3-70b-instruct-foo-test' is not supported","more_info":"https://cloud.ibm.com/apidocs/watsonx-ai#text-generation"}],"trace":"3a8e0587e089f3d55d8f5d16f4f90d7c","status_code":404}
```

## Discussion Topics
- It would simplify the retry.go logic if we could just make breaking changes and document them. It seems that although the `Retry` function and the `RetryConfig` are exported and visible, it is very likely that the consumers of the existing behavior will not have tried to alter the default behavior, and so we could possibly just update the code and document a migration path forward.  The migration in such a case would be minimal in that the GenerateText and EmbedDocuments still return an error response as before, but the error response is just a richer response with more details.  
- The current PR is a bit more complex than it needs to be because it is trying to preserve backwards compatibility in the Retry logic by maintaining v1 and v2 logic and switch between them via the flag `returnHTTPStatusAsErr`.

