### PR TITLE
Add text-chat API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,59 @@ for data := range dataChan {
 }
 ```
 
+#### Chat Completions
+
+Simple chat with a single message:
+
+```go
+response, _ := client.SimpleChat(
+  "meta-llama/llama-3-3-70b-instruct",
+  "What is the capital of France?",
+  wx.WithChatTemperature(0.3),
+  wx.WithChatMaxTokens(100),
+)
+
+println(response) // prints the assistant's response text
+```
+
+Multi-turn conversation:
+
+```go
+messages := []wx.ChatMessage{
+  wx.CreateSystemMessage("You are a helpful assistant."),
+  wx.CreateUserMessage("What is the capital of France?"),
+}
+
+response, _ := client.Chat(
+  "meta-llama/llama-3-3-70b-instruct",
+  messages,
+  wx.WithChatTemperature(0.3),
+  wx.WithChatMaxTokens(100),
+)
+
+content := response.Choices[0].Message.Content.GetText()
+println(content)
+```
+
+Chat with JSON mode:
+
+```go
+messages := []wx.ChatMessage{
+  wx.CreateSystemMessage("You respond in JSON format."),
+  wx.CreateUserMessage("What is 2+2? Respond with {\"answer\": number}"),
+}
+
+response, _ := client.Chat(
+  "meta-llama/llama-3-3-70b-instruct",
+  messages,
+  wx.WithChatJSONMode(),
+  wx.WithChatTemperature(0.1),
+)
+
+jsonResponse := response.Choices[0].Message.Content.GetText()
+println(jsonResponse) // {"answer": 4}
+```
+
 #### Generate Embeddings
 
 Embedding | Single query:

--- a/pkg/internal/tests/models/chat_test.go
+++ b/pkg/internal/tests/models/chat_test.go
@@ -1,0 +1,174 @@
+package test
+
+import (
+	"strings"
+	"testing"
+
+	wx "github.com/IBM/watsonx-go/pkg/models"
+)
+
+const (
+	modelChatLlama3Integration  = "meta-llama/llama-3-3-70b-instruct"
+	modelChatInvalidIntegration = "invalid-chat-model-test"
+)
+
+func TestChatSingleMessage(t *testing.T) {
+	client := getClient(t)
+
+	messages := []wx.ChatMessage{
+		wx.CreateUserMessage("What is the capital of France?"),
+	}
+
+	response, err := client.Chat(modelChatLlama3Integration, messages)
+
+	if err != nil {
+		t.Fatalf("Expected no error for chat request, but got %v", err)
+	}
+
+	if len(response.Choices) == 0 {
+		t.Fatal("Expected at least one choice in response")
+	}
+
+	if response.Choices[0].Message == nil {
+		t.Fatal("Expected message in first choice")
+	}
+
+	content := response.Choices[0].Message.Content.GetText()
+	if content == "" {
+		t.Fatal("Expected non-empty response content")
+	}
+
+	if response.ModelID == "" {
+		t.Fatal("Expected model ID to be set in response")
+	}
+
+	if response.Usage == nil {
+		t.Fatal("Expected usage information in response")
+	}
+}
+
+func TestChatMultipleMessages(t *testing.T) {
+	client := getClient(t)
+
+	messages := []wx.ChatMessage{
+		wx.CreateSystemMessage("You are a helpful assistant that answers in one word."),
+		wx.CreateUserMessage("What is 2+2?"),
+	}
+
+	response, err := client.Chat(
+		modelChatLlama3Integration,
+		messages,
+		wx.WithChatTemperature(0.3),
+		wx.WithChatMaxTokens(10),
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error for chat request, but got %v", err)
+	}
+
+	if len(response.Choices) == 0 {
+		t.Fatal("Expected at least one choice in response")
+	}
+
+	content := response.Choices[0].Message.Content.GetText()
+	if content == "" {
+		t.Fatal("Expected non-empty response content")
+	}
+
+	if response.Usage.TotalTokens == 0 {
+		t.Fatal("Expected non-zero total tokens")
+	}
+
+	if response.Usage.CompletionTokens > 3 {
+		t.Fatal("Expected completion tokens to be less than or equal to 3")
+	}
+
+	lowerContent := strings.ToLower(content)
+	if !strings.Contains(lowerContent, "four") && !strings.Contains(lowerContent, "4") {
+		t.Fatal("Expected response to contain 'four' or '4'")
+	}
+}
+
+func TestSimpleChat(t *testing.T) {
+	client := getClient(t)
+
+	response, err := client.SimpleChat(
+		modelChatLlama3Integration,
+		"Say 'hello' in French in one word",
+		wx.WithChatTemperature(0.1),
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error for simple chat, but got %v", err)
+	}
+
+	if response == "" {
+		t.Fatal("Expected non-empty response")
+	}
+
+	lowerResponse := strings.ToLower(response)
+	if !strings.Contains(lowerResponse, "bonjour") {
+		t.Fatal("Expected response to contain 'bonjour'")
+	}
+}
+
+func TestChatWithJSONMode(t *testing.T) {
+	client := getClient(t)
+
+	messages := []wx.ChatMessage{
+		wx.CreateSystemMessage("You are a helpful assistant that responds in JSON format."),
+		wx.CreateUserMessage("What is the capital of France? Respond with {\"capital\": \"city_name\"}"),
+	}
+
+	response, err := client.Chat(
+		modelChatLlama3Integration,
+		messages,
+		wx.WithChatJSONMode(),
+		wx.WithChatTemperature(0.1),
+	)
+
+	if err != nil {
+		t.Fatalf("Expected no error for JSON mode chat, but got %v", err)
+	}
+
+	if len(response.Choices) == 0 {
+		t.Fatal("Expected at least one choice in response")
+	}
+
+	content := response.Choices[0].Message.Content.GetText()
+	if content == "" {
+		t.Fatal("Expected non-empty response content")
+	}
+}
+
+func TestChatInvalidModel(t *testing.T) {
+	client := getClient(t)
+
+	messages := []wx.ChatMessage{
+		wx.CreateUserMessage("Hello"),
+	}
+
+	_, err := client.Chat(modelChatInvalidIntegration, messages)
+
+	if err == nil {
+		t.Fatal("Expected error for invalid model but got nil")
+	}
+}
+
+func TestChatInvalidParameter(t *testing.T) {
+	client := getClient(t)
+
+	messages := []wx.ChatMessage{
+		wx.CreateUserMessage("Hello"),
+	}
+
+	_, err := client.Chat(
+		modelChatLlama3Integration,
+		messages,
+		wx.WithChatTemperature(100), // Invalid temperature - should be 0-2
+	)
+
+	if err == nil {
+		t.Fatal("Expected error for invalid parameter but got nil")
+	}
+}

--- a/pkg/models/chat.go
+++ b/pkg/models/chat.go
@@ -1,0 +1,448 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+// API endpoints
+const (
+	ChatEndpoint       string = "/ml/v1/text/chat"
+	ChatStreamEndpoint string = "/ml/v1/text/chat_stream"
+)
+
+// Chat response body
+const (
+	errorChatBodyBufferSize = 1024
+)
+
+// Message roles
+const (
+	RoleSystem    = "system"
+	RoleUser      = "user"
+	RoleAssistant = "assistant"
+	RoleTool      = "tool"
+)
+
+// Chat message content types
+type ChatMessageContent struct {
+	Type     string        `json:"type"` // "text", "image_url", etc.
+	Text     *string       `json:"text,omitempty"`
+	ImageURL *ChatImageURL `json:"image_url,omitempty"`
+}
+
+type ChatImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"` // "low", "high", "auto"
+}
+
+// Chat message structure that handles both string and array content formats
+type ChatMessage struct {
+	Role       string                  `json:"role"`
+	Content    ChatMessageContentUnion `json:"content"`
+	Name       *string                 `json:"name,omitempty"`
+	ToolCalls  []ChatToolCall          `json:"tool_calls,omitempty"`
+	ToolCallID *string                 `json:"tool_call_id,omitempty"`
+}
+
+// ChatMessageContentUnion handles both string and array formats
+type ChatMessageContentUnion struct {
+	StringContent *string              `json:"-"`
+	ArrayContent  []ChatMessageContent `json:"-"`
+}
+
+// UnmarshalJSON implements custom unmarshaling to handle both string and array content
+func (c *ChatMessageContentUnion) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal as string first
+	var str string
+	if err := json.Unmarshal(data, &str); err == nil {
+		c.StringContent = &str
+		return nil
+	}
+
+	// Try to unmarshal as array
+	var arr []ChatMessageContent
+	if err := json.Unmarshal(data, &arr); err == nil {
+		c.ArrayContent = arr
+		return nil
+	}
+
+	return fmt.Errorf("content must be either string or array of ChatMessageContent")
+}
+
+// MarshalJSON implements custom marshaling
+func (c *ChatMessageContentUnion) MarshalJSON() ([]byte, error) {
+	if c.StringContent != nil {
+		return json.Marshal(*c.StringContent)
+	}
+	if c.ArrayContent != nil {
+		return json.Marshal(c.ArrayContent)
+	}
+	return json.Marshal([]ChatMessageContent{})
+}
+
+// GetText returns the text content regardless of format
+func (c *ChatMessageContentUnion) GetText() string {
+	if c.StringContent != nil {
+		return *c.StringContent
+	}
+	if len(c.ArrayContent) > 0 && c.ArrayContent[0].Text != nil {
+		return *c.ArrayContent[0].Text
+	}
+	return ""
+}
+
+// ToArray converts the content to array format
+func (c *ChatMessageContentUnion) ToArray() []ChatMessageContent {
+	if c.ArrayContent != nil {
+		return c.ArrayContent
+	}
+	if c.StringContent != nil {
+		return []ChatMessageContent{
+			{
+				Type: "text",
+				Text: c.StringContent,
+			},
+		}
+	}
+	return []ChatMessageContent{}
+}
+
+// Tool definitions
+type ChatTool struct {
+	Type     string           `json:"type"` // "function"
+	Function ChatToolFunction `json:"function"`
+}
+
+type ChatToolFunction struct {
+	Name        string      `json:"name"`
+	Description *string     `json:"description,omitempty"`
+	Parameters  interface{} `json:"parameters,omitempty"` // JSON schema
+}
+
+// Tool calls in responses
+type ChatToolCall struct {
+	ID       string               `json:"id"`
+	Type     string               `json:"type"` // "function"
+	Function ChatToolCallFunction `json:"function"`
+}
+
+type ChatToolCallFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string
+}
+
+// Tool choice options
+type ChatToolChoice struct {
+	Type     string                  `json:"type"` // "function"
+	Function *ChatToolChoiceFunction `json:"function,omitempty"`
+}
+
+type ChatToolChoiceFunction struct {
+	Name string `json:"name"`
+}
+
+// Response format options
+type ChatResponseFormat struct {
+	Type       string      `json:"type"` // "text", "json_object", "json_schema"
+	JSONSchema interface{} `json:"json_schema,omitempty"`
+}
+
+// Chat completion request
+type ChatRequest struct {
+	ModelID             string              `json:"model_id"`
+	Messages            []ChatMessage       `json:"messages"`
+	ProjectID           *string             `json:"project_id,omitempty"`
+	SpaceID             *string             `json:"space_id,omitempty"`
+	Tools               []ChatTool          `json:"tools,omitempty"`
+	ToolChoiceOption    *string             `json:"tool_choice_option,omitempty"` // "auto", "none", "required"
+	ToolChoice          *ChatToolChoice     `json:"tool_choice,omitempty"`
+	Context             *string             `json:"context,omitempty"`
+	MaxTokens           *uint               `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *uint               `json:"max_completion_tokens,omitempty"`
+	Temperature         *float64            `json:"temperature,omitempty"`
+	TopP                *float64            `json:"top_p,omitempty"`
+	FrequencyPenalty    *float64            `json:"frequency_penalty,omitempty"`
+	PresencePenalty     *float64            `json:"presence_penalty,omitempty"`
+	Stop                []string            `json:"stop,omitempty"`
+	N                   *uint               `json:"n,omitempty"`
+	Stream              *bool               `json:"stream,omitempty"`
+	ResponseFormat      *ChatResponseFormat `json:"response_format,omitempty"`
+	Seed                *int                `json:"seed,omitempty"`
+	TimeLimit           *uint               `json:"time_limit,omitempty"`
+}
+
+// Chat completion response
+type ChatResponse struct {
+	ID           string         `json:"id"`
+	ModelID      string         `json:"model_id"`
+	Created      int64          `json:"created"`
+	CreatedAt    *time.Time     `json:"created_at,omitempty"`
+	Choices      []ChatChoice   `json:"choices"`
+	Usage        *ChatUsage     `json:"usage,omitempty"`
+	ModelVersion *string        `json:"model_version,omitempty"`
+	System       *SystemDetails `json:"system,omitempty"`
+}
+
+type ChatChoice struct {
+	Index        int           `json:"index"`
+	Message      *ChatMessage  `json:"message,omitempty"`
+	Delta        *ChatMessage  `json:"delta,omitempty"` // For streaming
+	FinishReason *string       `json:"finish_reason,omitempty"`
+	LogProbs     *ChatLogProbs `json:"logprobs,omitempty"`
+}
+
+type ChatUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+type ChatLogProbs struct {
+	Content []ChatContentLogProbs `json:"content,omitempty"`
+	Refusal []ChatContentLogProbs `json:"refusal,omitempty"`
+}
+
+type ChatContentLogProbs struct {
+	Token       string           `json:"token"`
+	LogProb     float64          `json:"logprob"`
+	Bytes       []int            `json:"bytes,omitempty"`
+	TopLogProbs []ChatTopLogProb `json:"top_logprobs,omitempty"`
+}
+
+type ChatTopLogProb struct {
+	Token   string  `json:"token"`
+	LogProb float64 `json:"logprob"`
+	Bytes   []int   `json:"bytes,omitempty"`
+}
+
+// SystemDetails represents system information from the response
+type SystemDetails struct {
+	Warnings interface{} `json:"warnings,omitempty"`
+}
+
+const ChatMessageTypeText = "text"
+
+// CreateChatMessage creates a text message with the specified role and content
+func CreateChatMessage(role string, content ChatMessageContentUnion) ChatMessage {
+	return ChatMessage{
+		Role:    role,
+		Content: content,
+	}
+}
+
+// CreateFunction creates a tool function definition
+func CreateFunction(name, description string, parameters interface{}) ChatTool {
+	return ChatTool{
+		Type: "function",
+		Function: ChatToolFunction{
+			Name:        name,
+			Description: &description,
+			Parameters:  parameters,
+		},
+	}
+}
+
+// CreateToolMessage creates a tool response message
+func CreateToolMessage(toolCallID, content string) ChatMessage {
+	return ChatMessage{
+		Role: RoleTool,
+		Content: ChatMessageContentUnion{
+			ArrayContent: []ChatMessageContent{
+				{
+					Type: ChatMessageTypeText,
+					Text: &content,
+				},
+			},
+		},
+		ToolCallID: &toolCallID,
+	}
+}
+
+// CreateSystemMessage creates a system message
+func CreateSystemMessage(content string) ChatMessage {
+	stringContent := ChatMessageContentUnion{
+		StringContent: &content,
+	}
+	return CreateChatMessage(RoleSystem, stringContent)
+}
+
+// CreateUserMessage creates a user message
+func CreateUserMessage(content string) ChatMessage {
+	arrayContent := ChatMessageContentUnion{
+		ArrayContent: []ChatMessageContent{
+			{
+				Type: ChatMessageTypeText,
+				Text: &content,
+			},
+		},
+	}
+
+	return CreateChatMessage(RoleUser, arrayContent)
+}
+
+// CreateAssistantMessage creates an assistant message
+func CreateAssistantMessage(content string) ChatMessage {
+	arrayContent := ChatMessageContentUnion{
+		ArrayContent: []ChatMessageContent{
+			{
+				Type: ChatMessageTypeText,
+				Text: &content,
+			},
+		},
+	}
+	return CreateChatMessage(RoleAssistant, arrayContent)
+}
+
+// Chat generates a text chat based on messages and parameters
+func (c *Client) Chat(modelID string, messages []ChatMessage, options ...ChatOption) (ChatResponse, error) {
+	// Validate input
+	if modelID == "" {
+		return ChatResponse{}, errors.New("modelID cannot be empty")
+	}
+
+	if len(messages) == 0 {
+		return ChatResponse{}, errors.New("messages cannot be empty")
+	}
+
+	// Apply options
+	opts := &ChatOptions{}
+	for _, opt := range options {
+		if opt != nil {
+			opt(opts)
+		}
+	}
+
+	// Build the request payload
+	payload := c.BuildChatRequest(modelID, messages, opts)
+
+	// Make the API request
+	response, err := c.generateChatRequest(payload)
+	if err != nil {
+		return ChatResponse{}, err
+	}
+
+	// Validate response
+	if len(response.Choices) == 0 {
+		return ChatResponse{}, errors.New("no choices received in response")
+	}
+
+	return response, nil
+}
+
+// SimpleChat provides a simple interface for single-turn text chat conversations
+func (c *Client) SimpleChat(modelID, prompt string, options ...ChatOption) (string, error) {
+	messages := []ChatMessage{
+		CreateUserMessage(prompt),
+	}
+
+	response, err := c.Chat(modelID, messages, options...)
+	if err != nil {
+		return "", err
+	}
+
+	if len(response.Choices) == 0 || response.Choices[0].Message == nil {
+		return "", errors.New("no response received")
+	}
+
+	choice := response.Choices[0]
+	if choice.Message == nil {
+		return "", errors.New("no message in response")
+	}
+
+	text := choice.Message.Content.GetText()
+	if text == "" {
+		return "", errors.New("no text content in response")
+	}
+
+	return text, nil
+}
+
+// BuildChatRequest constructs the ChatRequest payload
+func (c *Client) BuildChatRequest(modelID string, messages []ChatMessage, opts *ChatOptions) ChatRequest {
+	// Use the project ID from the client (already configured during client creation)
+	projectID := string(c.projectID)
+
+	payload := ChatRequest{
+		ModelID:             modelID,
+		Messages:            messages,
+		ProjectID:           &projectID,
+		Tools:               opts.Tools,
+		ToolChoiceOption:    opts.ToolChoiceOption,
+		ToolChoice:          opts.ToolChoice,
+		Context:             opts.Context,
+		MaxTokens:           opts.MaxTokens,
+		MaxCompletionTokens: opts.MaxCompletionTokens,
+		Temperature:         opts.Temperature,
+		TopP:                opts.TopP,
+		FrequencyPenalty:    opts.FrequencyPenalty,
+		PresencePenalty:     opts.PresencePenalty,
+		Stop:                opts.Stop,
+		N:                   opts.N,
+		ResponseFormat:      opts.ResponseFormat,
+		Seed:                opts.Seed,
+		TimeLimit:           opts.TimeLimit,
+	}
+
+	return payload
+}
+
+// generateChatRequest sends a request to the chat endpoint
+func (c *Client) generateChatRequest(payload ChatRequest) (ChatResponse, error) {
+	// Ensure we have a valid token
+	err := c.CheckAndRefreshToken()
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to refresh token: %w", err)
+	}
+
+	// Build the URL using the client's configuration
+	chatURL := c.generateUrlFromEndpoint(ChatEndpoint)
+
+	// Marshal the payload to JSON
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to marshal request payload: %w", err)
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequest(http.MethodPost, chatURL, bytes.NewReader(payloadJSON))
+	if err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	// Set required headers
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.token.value)
+
+	// Execute the request using the client's HTTP client with retry
+	res, err := c.httpClient.DoWithRetry(req)
+	if err != nil {
+		return ChatResponse{}, err
+	}
+	defer func() {
+		if cerr := res.Body.Close(); cerr != nil {
+			log.Println("error closing response body: ", cerr)
+		}
+	}()
+
+	// Check for successful status code
+	if res.StatusCode != http.StatusOK {
+		// Read response body for error details
+		body := make([]byte, errorChatBodyBufferSize)
+		n, _ := res.Body.Read(body)
+		return ChatResponse{}, errors.New(string(body[:n]))
+	}
+
+	// Decode the response
+	var chatRes ChatResponse
+	if err := json.NewDecoder(res.Body).Decode(&chatRes); err != nil {
+		return ChatResponse{}, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return chatRes, nil
+}

--- a/pkg/models/chat_option.go
+++ b/pkg/models/chat_option.go
@@ -1,0 +1,165 @@
+package models
+
+// ChatOption defines the function signature for chat configuration options
+type ChatOption func(*ChatOptions)
+
+// ChatOptions holds all the configurable parameters for chat requests
+type ChatOptions struct {
+	Tools               []ChatTool          `json:"tools,omitempty"`
+	ToolChoiceOption    *string             `json:"tool_choice_option,omitempty"`
+	ToolChoice          *ChatToolChoice     `json:"tool_choice,omitempty"`
+	Context             *string             `json:"context,omitempty"`
+	MaxTokens           *uint               `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *uint               `json:"max_completion_tokens,omitempty"`
+	Temperature         *float64            `json:"temperature,omitempty"`
+	TopP                *float64            `json:"top_p,omitempty"`
+	FrequencyPenalty    *float64            `json:"frequency_penalty,omitempty"`
+	PresencePenalty     *float64            `json:"presence_penalty,omitempty"`
+	Stop                []string            `json:"stop,omitempty"`
+	N                   *uint               `json:"n,omitempty"`
+	ResponseFormat      *ChatResponseFormat `json:"response_format,omitempty"`
+	Seed                *int                `json:"seed,omitempty"`
+	TimeLimit           *uint               `json:"time_limit,omitempty"`
+	LogitBias           map[string]float64  `json:"logit_bias,omitempty"`
+	LogProbs            *bool               `json:"logprobs,omitempty"`
+	TopLogProbs         *uint               `json:"top_logprobs,omitempty"`
+}
+
+// WithChatTools sets the tools available for the chat completion
+func WithChatTools(tools ...ChatTool) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.Tools = tools
+	}
+}
+
+// WithChatToolChoice sets how the model should use tools
+func WithChatToolChoice(choice string) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.ToolChoiceOption = &choice
+	}
+}
+
+// WithChatToolChoiceFunction forces the model to use a specific function
+func WithChatToolChoiceFunction(name string) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.ToolChoice = &ChatToolChoice{
+			Type:     "function",
+			Function: &ChatToolChoiceFunction{Name: name},
+		}
+	}
+}
+
+// WithChatContext sets additional context for the chat completion
+func WithChatContext(context string) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.Context = &context
+	}
+}
+
+// WithChatMaxTokens sets the maximum number of tokens to generate
+func WithChatMaxTokens(maxTokens uint) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.MaxTokens = &maxTokens
+	}
+}
+
+// WithChatMaxCompletionTokens sets the maximum number of completion tokens
+func WithChatMaxCompletionTokens(maxTokens uint) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.MaxCompletionTokens = &maxTokens
+	}
+}
+
+// WithChatTemperature sets the sampling temperature
+func WithChatTemperature(temperature float64) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.Temperature = &temperature
+	}
+}
+
+// WithChatTopP sets the nucleus sampling parameter
+func WithChatTopP(topP float64) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.TopP = &topP
+	}
+}
+
+// WithChatFrequencyPenalty sets the frequency penalty
+func WithChatFrequencyPenalty(penalty float64) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.FrequencyPenalty = &penalty
+	}
+}
+
+// WithChatPresencePenalty sets the presence penalty
+func WithChatPresencePenalty(penalty float64) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.PresencePenalty = &penalty
+	}
+}
+
+// WithChatStop sets the stop sequences
+func WithChatStop(stop ...string) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.Stop = stop
+	}
+}
+
+// WithChatN sets the number of chat completion choices to generate
+func WithChatN(n uint) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.N = &n
+	}
+}
+
+// WithChatJSONMode enables JSON mode for the response
+func WithChatJSONMode() ChatOption {
+	return func(opts *ChatOptions) {
+		opts.ResponseFormat = &ChatResponseFormat{Type: "json_object"}
+	}
+}
+
+// WithChatJSONSchema sets a JSON schema for structured output
+func WithChatJSONSchema(schema interface{}) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.ResponseFormat = &ChatResponseFormat{
+			Type:       "json_schema",
+			JSONSchema: schema,
+		}
+	}
+}
+
+// WithChatSeed sets the random seed for reproducible outputs
+func WithChatSeed(seed int) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.Seed = &seed
+	}
+}
+
+// WithChatTimeLimit sets the time limit for the request
+func WithChatTimeLimit(timeLimit uint) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.TimeLimit = &timeLimit
+	}
+}
+
+// WithChatLogitBias sets the logit bias for token selection
+func WithChatLogitBias(logitBias map[string]float64) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.LogitBias = logitBias
+	}
+}
+
+// WithChatLogProbs enables or disables log probabilities in the response
+func WithChatLogProbs(logProbs bool) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.LogProbs = &logProbs
+	}
+}
+
+// WithChatTopLogProbs sets the number of most likely tokens to return at each position
+func WithChatTopLogProbs(topLogProbs uint) ChatOption {
+	return func(opts *ChatOptions) {
+		opts.TopLogProbs = &topLogProbs
+	}
+}


### PR DESCRIPTION
# Add SDK support for the text-chat API

Issue https://github.com/IBM/watsonx-go/issues/21

This PR introduces text chat support to the watsonx-go library adhering to the specifications in the [text-chat API](https://cloud.ibm.com/apidocs/watsonx-ai#text-chat).

## Description
Previously, there was no support for the text-chat API.  This change adds new functions Chat (for full conversations) and , SimpleChat (for single prompts) to the client which invoke the the text-chat API using the endpoint `/ml/v1/text/chat`.


## Code Changes

### New functions
- Add new `SimpleChat` function which takes a simple string message
- Add new `Chat` function which takes an array of ChatMessage 
- Add support for 

### Parameters Supported:
- Generation controls: temperature, top-p, max tokens, penalties
- Tool configuration: tool choice options, function selection
- Output formatting: JSON mode, stop sequences, seed for reproducibility
- Advanced features: logit bias, log probabilities, time limits

### Test Coverage:

- `TestChatSingleMessage`: Basic single-turn conversation validation
- `TestChatMultipleMessages`: Multi-turn chat with system prompts and parameter validation
- `TestSimpleChat`: Convenience method testing with specific response validation
- `TestChatWithJSONMode`: JSON response format functionality
- `TestChatInvalidModel`: Error handling for non-existent models
- `TestChatInvalidParameter`: Parameter validation (temperature out of range)
